### PR TITLE
[FEAT] 카카오 map api 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+backend/src/main/resources/application-env.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly 'com.h2database:h2:1.4.200'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'

--- a/backend/src/main/java/com/twtw/backend/config/client/WebClientConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/client/WebClientConfig.java
@@ -1,7 +1,9 @@
 package com.twtw.backend.config.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,11 +22,17 @@ public class WebClientConfig {
     public WebClient webClient(
             @Value("${kakao-map.url}") final String url,
             @Value("${kakao-map.key}") final String authHeader) {
-        final ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
-                .codecs(configurer -> {
-                    configurer.defaultCodecs().maxInMemorySize(-1);
-                    configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper));
-                }).build();
+        final ExchangeStrategies exchangeStrategies =
+                ExchangeStrategies.builder()
+                        .codecs(
+                                configurer -> {
+                                    configurer.defaultCodecs().maxInMemorySize(-1);
+                                    configurer
+                                            .defaultCodecs()
+                                            .jackson2JsonDecoder(
+                                                    new Jackson2JsonDecoder(objectMapper));
+                                })
+                        .build();
 
         return WebClient.builder()
                 .exchangeStrategies(exchangeStrategies)

--- a/backend/src/main/java/com/twtw/backend/config/client/WebClientConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/client/WebClientConfig.java
@@ -1,0 +1,35 @@
+package com.twtw.backend.config.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+    private static final String HEADER_PREFIX = "KakaoAK ";
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public WebClient webClient(
+            @Value("${kakao-map.url}") final String url,
+            @Value("${kakao-map.key}") final String authHeader) {
+        final ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+                .codecs(configurer -> {
+                    configurer.defaultCodecs().maxInMemorySize(-1);
+                    configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper));
+                }).build();
+
+        return WebClient.builder()
+                .exchangeStrategies(exchangeStrategies)
+                .baseUrl(url)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, HEADER_PREFIX + authHeader)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/config/mapper/ObjectMapperConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/mapper/ObjectMapperConfig.java
@@ -1,0 +1,18 @@
+package com.twtw.backend.config.mapper;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/config/mapper/ObjectMapperConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/mapper/ObjectMapperConfig.java
@@ -3,6 +3,7 @@ package com.twtw.backend.config.mapper;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
                                                 "/v3/api-docs/**",
                                                 "/swagger-ui/**",
                                                 "/swagger-ui.html",
-                                                "auth/**", "/plans/**")
+                                                "auth/**",
+                                                "/plans/**")
                                         .permitAll())
                 .authorizeHttpRequests(
                         x -> x.requestMatchers("/test/**").permitAll().anyRequest().authenticated())

--- a/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
@@ -34,8 +34,7 @@ public class SecurityConfig {
                                                 "/v3/api-docs/**",
                                                 "/swagger-ui/**",
                                                 "/swagger-ui.html",
-                                                "auth/**",
-                                                "/plans/**")
+                                                "auth/**")
                                         .permitAll())
                 .authorizeHttpRequests(
                         x -> x.requestMatchers("/test/**").permitAll().anyRequest().authenticated())

--- a/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                                                 "/v3/api-docs/**",
                                                 "/swagger-ui/**",
                                                 "/swagger-ui.html",
-                                                "auth/**")
+                                                "auth/**", "/plans/**")
                                         .permitAll())
                 .authorizeHttpRequests(
                         x -> x.requestMatchers("/test/**").permitAll().anyRequest().authenticated())

--- a/backend/src/main/java/com/twtw/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/twtw/backend/domain/member/repository/MemberRepository.java
@@ -14,6 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
 
     @Query(
             "SELECT m FROM Member m WHERE m.oAuth2Info.clientId = :oAuthId AND"
-                + " m.oAuth2Info.authType = :authType")
+                    + " m.oAuth2Info.authType = :authType")
     Optional<Member> findByOAuthIdAndAuthType(String oAuthId, AuthType authType);
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
@@ -50,7 +50,7 @@ public class SearchDestinationClient
 
         final CategoryGroupCode categoryGroupCode = request.getCategoryGroupCode();
 
-        if (categoryGroupCode == CategoryGroupCode.NONE) {
+        if (categoryGroupCode.isNone()) {
             return builder.build();
         }
         return builder.queryParam("category_group_code", categoryGroupCode).build();

--- a/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
@@ -5,7 +5,9 @@ import com.twtw.backend.domain.plan.dto.client.SearchDestinationResponse;
 import com.twtw.backend.domain.plan.entity.CategoryGroupCode;
 import com.twtw.backend.global.client.MapClient;
 import com.twtw.backend.global.exception.WebClientResponseException;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -16,14 +18,16 @@ import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
-public class SearchDestinationClient implements MapClient<SearchDestinationRequest, SearchDestinationResponse> {
+public class SearchDestinationClient
+        implements MapClient<SearchDestinationRequest, SearchDestinationResponse> {
     private static final Integer MAX_SIZE_PER_REQUEST = 15;
     private static final Integer DEFAULT_DISTANCE_RADIUS = 20000;
     private final WebClient webClient;
 
     @Override
     public SearchDestinationResponse request(final SearchDestinationRequest request) {
-        return webClient.get()
+        return webClient
+                .get()
                 .uri(uriBuilder -> getUri(request, uriBuilder))
                 .accept(MediaType.APPLICATION_JSON)
                 .acceptCharset(StandardCharsets.UTF_8)
@@ -34,22 +38,21 @@ public class SearchDestinationClient implements MapClient<SearchDestinationReque
     }
 
     private URI getUri(final SearchDestinationRequest request, final UriBuilder uriBuilder) {
-        final UriBuilder builder = uriBuilder
-                .path("search/keyword")
-                .queryParam("query", request.getQuery())
-                .queryParam("x", request.getX())
-                .queryParam("y", request.getY())
-                .queryParam("radius", DEFAULT_DISTANCE_RADIUS)
-                .queryParam("page", request.getPage())
-                .queryParam("size", MAX_SIZE_PER_REQUEST);
+        final UriBuilder builder =
+                uriBuilder
+                        .path("search/keyword")
+                        .queryParam("query", request.getQuery())
+                        .queryParam("x", request.getX())
+                        .queryParam("y", request.getY())
+                        .queryParam("radius", DEFAULT_DISTANCE_RADIUS)
+                        .queryParam("page", request.getPage())
+                        .queryParam("size", MAX_SIZE_PER_REQUEST);
 
         final CategoryGroupCode categoryGroupCode = request.getCategoryGroupCode();
 
         if (categoryGroupCode == CategoryGroupCode.NONE) {
             return builder.build();
         }
-        return builder
-                .queryParam("category_group_code", categoryGroupCode)
-                .build();
+        return builder.queryParam("category_group_code", categoryGroupCode).build();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
@@ -1,0 +1,55 @@
+package com.twtw.backend.domain.plan.client;
+
+import com.twtw.backend.domain.plan.dto.client.SearchDestinationRequest;
+import com.twtw.backend.domain.plan.dto.client.SearchDestinationResponse;
+import com.twtw.backend.domain.plan.entity.CategoryGroupCode;
+import com.twtw.backend.global.client.MapClient;
+import com.twtw.backend.global.exception.WebClientResponseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class SearchDestinationClient implements MapClient<SearchDestinationRequest, SearchDestinationResponse> {
+    private static final Integer MAX_SIZE_PER_REQUEST = 15;
+    private static final Integer DEFAULT_DISTANCE_RADIUS = 20000;
+    private final WebClient webClient;
+
+    @Override
+    public SearchDestinationResponse request(final SearchDestinationRequest request) {
+        return webClient.get()
+                .uri(uriBuilder -> getUri(request, uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .acceptCharset(StandardCharsets.UTF_8)
+                .retrieve()
+                .bodyToMono(SearchDestinationResponse.class)
+                .blockOptional()
+                .orElseThrow(WebClientResponseException::new);
+    }
+
+    private URI getUri(final SearchDestinationRequest request, final UriBuilder uriBuilder) {
+        final UriBuilder builder = uriBuilder
+                .path("search/keyword")
+                .queryParam("query", request.getQuery())
+                .queryParam("x", request.getX())
+                .queryParam("y", request.getY())
+                .queryParam("radius", DEFAULT_DISTANCE_RADIUS)
+                .queryParam("page", request.getPage())
+                .queryParam("size", MAX_SIZE_PER_REQUEST);
+
+        final CategoryGroupCode categoryGroupCode = request.getCategoryGroupCode();
+
+        if (categoryGroupCode == CategoryGroupCode.NONE) {
+            return builder.build();
+        }
+        return builder
+                .queryParam("category_group_code", categoryGroupCode)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
@@ -1,0 +1,20 @@
+package com.twtw.backend.domain.plan.controller;
+
+import com.twtw.backend.domain.plan.dto.client.SearchDestinationRequest;
+import com.twtw.backend.domain.plan.dto.response.PlanDestinationResponse;
+import com.twtw.backend.domain.plan.service.PlanService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("plans")
+@RequiredArgsConstructor
+public class PlanController {
+    private final PlanService planService;
+
+    @GetMapping("search/destination")
+    public ResponseEntity<PlanDestinationResponse> searchPlanDestination(@ModelAttribute final SearchDestinationRequest request) {
+        return ResponseEntity.ok(planService.searchPlanDestination(request));
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
@@ -3,7 +3,9 @@ package com.twtw.backend.domain.plan.controller;
 import com.twtw.backend.domain.plan.dto.client.SearchDestinationRequest;
 import com.twtw.backend.domain.plan.dto.response.PlanDestinationResponse;
 import com.twtw.backend.domain.plan.service.PlanService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,7 +16,8 @@ public class PlanController {
     private final PlanService planService;
 
     @GetMapping("search/destination")
-    public ResponseEntity<PlanDestinationResponse> searchPlanDestination(@ModelAttribute final SearchDestinationRequest request) {
+    public ResponseEntity<PlanDestinationResponse> searchPlanDestination(
+            @ModelAttribute final SearchDestinationRequest request) {
         return ResponseEntity.ok(planService.searchPlanDestination(request));
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/MetaDetails.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/MetaDetails.java
@@ -1,0 +1,12 @@
+package com.twtw.backend.domain.plan.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MetaDetails {
+    private Boolean isEnd;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/PlaceDetails.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/PlaceDetails.java
@@ -1,6 +1,7 @@
 package com.twtw.backend.domain.plan.dto.client;
 
 import com.twtw.backend.domain.plan.entity.CategoryGroupCode;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/PlaceDetails.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/PlaceDetails.java
@@ -1,0 +1,21 @@
+package com.twtw.backend.domain.plan.dto.client;
+
+import com.twtw.backend.domain.plan.entity.CategoryGroupCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceDetails {
+    private String placeName;
+    private String distance;
+    private String placeUrl;
+    private String categoryName;
+    private String addressName;
+    private String roadAddressName;
+    private CategoryGroupCode categoryGroupCode;
+    private String x;
+    private String y;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/SearchDestinationRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/SearchDestinationRequest.java
@@ -1,6 +1,7 @@
 package com.twtw.backend.domain.plan.dto.client;
 
 import com.twtw.backend.domain.plan.entity.CategoryGroupCode;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/SearchDestinationRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/SearchDestinationRequest.java
@@ -1,0 +1,19 @@
+package com.twtw.backend.domain.plan.dto.client;
+
+import com.twtw.backend.domain.plan.entity.CategoryGroupCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchDestinationRequest {
+    private String query;
+    private String x;
+    private String y;
+    private Integer page;
+    private CategoryGroupCode categoryGroupCode;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/SearchDestinationResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/SearchDestinationResponse.java
@@ -1,0 +1,15 @@
+package com.twtw.backend.domain.plan.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchDestinationResponse {
+    private MetaDetails meta;
+    private List<PlaceDetails> documents;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/response/PlanDestinationResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/response/PlanDestinationResponse.java
@@ -1,0 +1,14 @@
+package com.twtw.backend.domain.plan.dto.response;
+
+import com.twtw.backend.domain.plan.dto.client.PlaceDetails;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PlanDestinationResponse {
+    private List<PlaceDetails> results;
+    private Boolean isLast;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/response/PlanDestinationResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/response/PlanDestinationResponse.java
@@ -1,6 +1,7 @@
 package com.twtw.backend.domain.plan.dto.response;
 
 import com.twtw.backend.domain.plan.dto.client.PlaceDetails;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/CategoryGroupCode.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/CategoryGroupCode.java
@@ -25,4 +25,8 @@ public enum CategoryGroupCode {
     NONE("");
 
     private final String toKorean;
+
+    public boolean isNone() {
+        return this == NONE;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/CategoryGroupCode.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/CategoryGroupCode.java
@@ -1,0 +1,28 @@
+package com.twtw.backend.domain.plan.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum CategoryGroupCode {
+    MT1("대형마트"),
+    CS2("편의점"),
+    PS3("어린이집, 유치원"),
+    SC4("학교"),
+    AC5("학원"),
+    PK6("주차장"),
+    OL7("주유소, 충전소"),
+    SW8("지하철역"),
+    BK9("은행"),
+    CT1("문화시설"),
+    AG2("중개업소"),
+    PO3("공공기관"),
+    AT4("관광명소"),
+    AD5("숙박"),
+    FD6("음식점"),
+    CE7("카페"),
+    HP8("병원"),
+    PM9("약국"),
+    NONE("");
+
+    private final String toKorean;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
@@ -1,7 +1,9 @@
 package com.twtw.backend.domain.plan.entity;
 
 import com.twtw.backend.domain.member.entity.Member;
+
 import jakarta.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,8 +20,7 @@ public class Plan {
     @Column(columnDefinition = "BINARY(16)")
     private UUID id;
 
-    @Embedded
-    private PlanPlace planPlace;
+    @Embedded private PlanPlace planPlace;
 
     @OneToMany(mappedBy = "plan", cascade = CascadeType.PERSIST)
     private Set<PlanMember> planMembers = new HashSet<>();
@@ -31,8 +32,6 @@ public class Plan {
     }
 
     public void organizePlanMember(final List<Member> members) {
-        members.stream()
-                .map(member -> new PlanMember(this, member))
-                .forEach(this.planMembers::add);
+        members.stream().map(member -> new PlanMember(this, member)).forEach(this.planMembers::add);
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
@@ -1,0 +1,38 @@
+package com.twtw.backend.domain.plan.entity;
+
+import com.twtw.backend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Plan {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Embedded
+    private PlanPlace planPlace;
+
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.PERSIST)
+    private Set<PlanMember> planMembers = new HashSet<>();
+
+    @Builder
+    public Plan(final PlanPlace planPlace, final List<Member> members) {
+        this.planPlace = planPlace;
+        organizePlanMember(members);
+    }
+
+    public void organizePlanMember(final List<Member> members) {
+        members.stream()
+                .map(member -> new PlanMember(this, member))
+                .forEach(this.planMembers::add);
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanMember.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanMember.java
@@ -1,7 +1,9 @@
 package com.twtw.backend.domain.plan.entity;
 
 import com.twtw.backend.domain.member.entity.Member;
+
 import jakarta.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanMember.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanMember.java
@@ -1,0 +1,34 @@
+package com.twtw.backend.domain.plan.entity;
+
+import com.twtw.backend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlanMember {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @JoinColumn
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Plan plan;
+
+    @JoinColumn
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Builder
+    public PlanMember(final Plan plan, final Member member) {
+        this.plan = plan;
+        this.member = member;
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanPlace.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanPlace.java
@@ -1,6 +1,7 @@
 package com.twtw.backend.domain.plan.entity;
 
 import jakarta.persistence.Embeddable;
+
 import lombok.*;
 
 @Getter

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanPlace.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanPlace.java
@@ -1,0 +1,21 @@
+package com.twtw.backend.domain.plan.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Getter
+@Embeddable
+@AllArgsConstructor
+@EqualsAndHashCode(of = {"x", "y"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlanPlace {
+    private String placeName;
+    private String distance;
+    private String placeUrl;
+    private String categoryName;
+    private String addressName;
+    private String roadAddressName;
+    private CategoryGroupCode categoryGroupCode;
+    private String x;
+    private String y;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/repository/PlanRepository.java
@@ -1,6 +1,7 @@
 package com.twtw.backend.domain.plan.repository;
 
 import com.twtw.backend.domain.plan.entity.Plan;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;

--- a/backend/src/main/java/com/twtw/backend/domain/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,8 @@
+package com.twtw.backend.domain.plan.repository;
+
+import com.twtw.backend.domain.plan.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PlanRepository extends JpaRepository<Plan, UUID> {}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
@@ -5,7 +5,9 @@ import com.twtw.backend.domain.plan.dto.client.SearchDestinationResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanDestinationResponse;
 import com.twtw.backend.domain.plan.repository.PlanRepository;
 import com.twtw.backend.global.client.MapClient;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 
 @Service

--- a/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
@@ -1,0 +1,25 @@
+package com.twtw.backend.domain.plan.service;
+
+import com.twtw.backend.domain.plan.dto.client.SearchDestinationRequest;
+import com.twtw.backend.domain.plan.dto.client.SearchDestinationResponse;
+import com.twtw.backend.domain.plan.dto.response.PlanDestinationResponse;
+import com.twtw.backend.domain.plan.repository.PlanRepository;
+import com.twtw.backend.global.client.MapClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+    private final PlanRepository planRepository;
+    private final MapClient<SearchDestinationRequest, SearchDestinationResponse> destinationClient;
+
+    public PlanDestinationResponse searchPlanDestination(final SearchDestinationRequest request) {
+        final SearchDestinationResponse response = requestMapClient(request);
+        return new PlanDestinationResponse(response.getDocuments(), response.getMeta().getIsEnd());
+    }
+
+    private SearchDestinationResponse requestMapClient(final SearchDestinationRequest request) {
+        return destinationClient.request(request);
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/global/client/MapClient.java
+++ b/backend/src/main/java/com/twtw/backend/global/client/MapClient.java
@@ -1,0 +1,5 @@
+package com.twtw.backend.global.client;
+
+public interface MapClient<T, R> {
+    R request(T request);
+}

--- a/backend/src/main/java/com/twtw/backend/global/exception/WebClientResponseException.java
+++ b/backend/src/main/java/com/twtw/backend/global/exception/WebClientResponseException.java
@@ -1,0 +1,9 @@
+package com.twtw.backend.global.exception;
+
+public class WebClientResponseException extends IllegalArgumentException {
+    private static final String MESSAGE = "Rest API 호출에서 정상 응답을 받지 못했습니다.";
+
+    public WebClientResponseException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,20 @@
+server:
+  servlet:
+    context-path: /api/v1
+spring:
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/TWTW
+    username: root
+    password: root!
+  jpa:
+    database: mysql
+    generate-ddl: true
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+  main:
+    allow-bean-definition-overriding: true
+  config:
+    import:
+      - classpath:application-env.yml

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,0 +1,31 @@
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+    context-path: /api/v1
+
+spring:
+  config:
+    import:
+      - classpath:application-env.yml
+
+  main:
+    allow-bean-definition-overriding: true
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    database-platform: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,15 +1,3 @@
 spring:
   profiles:
-    include: env
-  datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://localhost:3306/TWTW
-    username: root
-    password: root!
-  jpa:
-    database: mysql
-    generate-ddl: true
-    show-sql: true
-    hibernate:
-      ddl-auto: create
-
+    active: dev

--- a/backend/src/test/java/com/twtw/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/twtw/backend/BackendApplicationTests.java
@@ -2,8 +2,10 @@ package com.twtw.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendApplicationTests {
 
     @Test


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 카카오 Map api 중 키워드를 통한 장소 검색 api 연동 완료
![MAPS_API결과](https://github.com/HongDam-org/TWTW/assets/89020004/4e7fa6c9-4ccf-44dc-920f-422a92d24a5f)

## 특이사항
- 파일 수가 많아져서 한 번 끊는 차원으로 PR 날림
- 노션의 application-env.yml 파일 내용 확인 부탁
- yml 파일 분리 했고, api prefix 설정 해둠
    - API URL이  http://localhost:8080/api/v1 으로 시작하도록 설정

## check list
- [ ] issue number를 브랜치 앞에 추가 했나요?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
