### PR TITLE
[FEAT] naver maps api

### DIFF
--- a/backend/src/main/java/com/twtw/backend/config/client/KakaoWebClientConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/client/KakaoWebClientConfig.java
@@ -1,0 +1,45 @@
+package com.twtw.backend.config.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class KakaoWebClientConfig {
+    private static final String HEADER_PREFIX = "KakaoAK ";
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    @Qualifier("KakaoWebClient")
+    public WebClient webClient(
+            @Value("${kakao-map.url}") final String url,
+            @Value("${kakao-map.key}") final String authHeader) {
+        final ExchangeStrategies exchangeStrategies =
+                ExchangeStrategies.builder()
+                        .codecs(
+                                configurer -> {
+                                    configurer.defaultCodecs().maxInMemorySize(-1);
+                                    configurer
+                                            .defaultCodecs()
+                                            .jackson2JsonDecoder(
+                                                    new Jackson2JsonDecoder(objectMapper));
+                                })
+                        .build();
+
+        return WebClient.builder()
+                .exchangeStrategies(exchangeStrategies)
+                .baseUrl(url)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, HEADER_PREFIX + authHeader)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/config/client/NaverWebClientConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/client/NaverWebClientConfig.java
@@ -1,27 +1,28 @@
 package com.twtw.backend.config.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @RequiredArgsConstructor
-public class WebClientConfig {
-    private static final String HEADER_PREFIX = "KakaoAK ";
+public class NaverWebClientConfig {
+    private static final String HEADER_CLIENT_ID = "X-NCP-APIGW-API-KEY-ID";
+    private static final String HEADER_CLIENT_SECRET = "X-NCP-APIGW-API-KEY";
     private final ObjectMapper objectMapper;
 
     @Bean
-    public WebClient webClient(
-            @Value("${kakao-map.url}") final String url,
-            @Value("${kakao-map.key}") final String authHeader) {
+    @Qualifier("NaverWebClient")
+    public WebClient webClient(@Value("${naver-map.url}") final String url,
+                               @Value("${naver-map.id}") final String clientId,
+                               @Value("${naver-map.secret}") final String secretKey){
+
         final ExchangeStrategies exchangeStrategies =
                 ExchangeStrategies.builder()
                         .codecs(
@@ -37,7 +38,8 @@ public class WebClientConfig {
         return WebClient.builder()
                 .exchangeStrategies(exchangeStrategies)
                 .baseUrl(url)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, HEADER_PREFIX + authHeader)
+                .defaultHeader(HEADER_CLIENT_ID,clientId)
+                .defaultHeader(HEADER_CLIENT_SECRET,secretKey)
                 .build();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/config/client/NaverWebClientConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/client/NaverWebClientConfig.java
@@ -1,7 +1,9 @@
 package com.twtw.backend.config.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -19,9 +21,10 @@ public class NaverWebClientConfig {
 
     @Bean
     @Qualifier("NaverWebClient")
-    public WebClient webClient(@Value("${naver-map.url}") final String url,
-                               @Value("${naver-map.id}") final String clientId,
-                               @Value("${naver-map.secret}") final String secretKey){
+    public WebClient webClient(
+            @Value("${naver-map.url}") final String url,
+            @Value("${naver-map.id}") final String clientId,
+            @Value("${naver-map.secret}") final String secretKey) {
 
         final ExchangeStrategies exchangeStrategies =
                 ExchangeStrategies.builder()
@@ -38,8 +41,8 @@ public class NaverWebClientConfig {
         return WebClient.builder()
                 .exchangeStrategies(exchangeStrategies)
                 .baseUrl(url)
-                .defaultHeader(HEADER_CLIENT_ID,clientId)
-                .defaultHeader(HEADER_CLIENT_SECRET,secretKey)
+                .defaultHeader(HEADER_CLIENT_ID, clientId)
+                .defaultHeader(HEADER_CLIENT_SECRET, secretKey)
                 .build();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
@@ -15,7 +15,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtFilter jwtFilter;

--- a/backend/src/main/java/com/twtw/backend/domain/SwaggerConfiguration.java
+++ b/backend/src/main/java/com/twtw/backend/domain/SwaggerConfiguration.java
@@ -1,4 +1,4 @@
-package com.twtw.backend.domain.member;
+package com.twtw.backend.domain;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/backend/src/main/java/com/twtw/backend/domain/path/client/SearchPathClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/client/SearchPathClient.java
@@ -1,0 +1,23 @@
+package com.twtw.backend.domain.path.client;
+
+import com.twtw.backend.domain.path.dto.client.SearchPathRequest;
+import com.twtw.backend.domain.path.dto.client.SearchPathResponse;
+import com.twtw.backend.global.client.PathClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+
+import java.net.URI;
+
+@Component
+public class SearchPathClient implements PathClient<SearchPathRequest, SearchPathResponse> {
+    @Qualifier("NaverWebClient")
+    private final WebClient webClient;
+
+    public SearchPathClient(WebClient webClient){
+        this.webClient = webClient;
+    }
+
+
+}

--- a/backend/src/main/java/com/twtw/backend/domain/path/client/SearchPathClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/client/SearchPathClient.java
@@ -2,13 +2,18 @@ package com.twtw.backend.domain.path.client;
 
 import com.twtw.backend.domain.path.dto.client.SearchPathRequest;
 import com.twtw.backend.domain.path.dto.client.SearchPathResponse;
+import com.twtw.backend.domain.plan.dto.client.SearchDestinationResponse;
 import com.twtw.backend.global.client.PathClient;
+import com.twtw.backend.global.exception.WebClientResponseException;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriBuilder;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
 
 @Component
 public class SearchPathClient implements PathClient<SearchPathRequest, SearchPathResponse> {
@@ -19,5 +24,27 @@ public class SearchPathClient implements PathClient<SearchPathRequest, SearchPat
         this.webClient = webClient;
     }
 
+    /*상세 검색을 위한 변경 필요*/
+    private URI getPathUri(final SearchPathRequest request, final UriBuilder uriBuilder){
+        final UriBuilder builder =
+                uriBuilder.
+                        path("driving")
+                        .queryParam("start",request.getStart())
+                        .queryParam("goal",request.getEnd());
 
+        return builder.build();
+    }
+
+    @Override
+    public String request(final SearchPathRequest request) {
+        return webClient
+                .get()
+                .uri(uri -> getPathUri(request,uri))
+                .accept(MediaType.APPLICATION_JSON)
+                .acceptCharset(StandardCharsets.UTF_8)
+                .retrieve()
+                .bodyToMono(String.class)
+                .blockOptional()
+                .orElseThrow(WebClientResponseException::new);
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/client/SearchPathClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/client/SearchPathClient.java
@@ -2,9 +2,9 @@ package com.twtw.backend.domain.path.client;
 
 import com.twtw.backend.domain.path.dto.client.SearchPathRequest;
 import com.twtw.backend.domain.path.dto.client.SearchPathResponse;
-import com.twtw.backend.domain.plan.dto.client.SearchDestinationResponse;
 import com.twtw.backend.global.client.PathClient;
 import com.twtw.backend.global.exception.WebClientResponseException;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -14,23 +14,22 @@ import org.springframework.web.util.UriBuilder;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
-
 @Component
 public class SearchPathClient implements PathClient<SearchPathRequest, SearchPathResponse> {
     @Qualifier("NaverWebClient")
     private final WebClient webClient;
 
-    public SearchPathClient(WebClient webClient){
+    public SearchPathClient(WebClient webClient) {
         this.webClient = webClient;
     }
 
     /*상세 검색을 위한 변경 필요*/
-    private URI getPathUri(final SearchPathRequest request, final UriBuilder uriBuilder){
+    private URI getPathUri(final SearchPathRequest request, final UriBuilder uriBuilder) {
         final UriBuilder builder =
-                uriBuilder.
-                        path("driving")
-                        .queryParam("start",request.getStart())
-                        .queryParam("goal",request.getEnd());
+                uriBuilder
+                        .path("driving")
+                        .queryParam("start", request.getStart())
+                        .queryParam("goal", request.getEnd());
 
         return builder.build();
     }
@@ -39,7 +38,7 @@ public class SearchPathClient implements PathClient<SearchPathRequest, SearchPat
     public String request(final SearchPathRequest request) {
         return webClient
                 .get()
-                .uri(uri -> getPathUri(request,uri))
+                .uri(uri -> getPathUri(request, uri))
                 .accept(MediaType.APPLICATION_JSON)
                 .acceptCharset(StandardCharsets.UTF_8)
                 .retrieve()

--- a/backend/src/main/java/com/twtw/backend/domain/path/controller/PathController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/controller/PathController.java
@@ -1,0 +1,21 @@
+package com.twtw.backend.domain.path.controller;
+
+import com.twtw.backend.domain.path.dto.client.SearchPathRequest;
+import com.twtw.backend.domain.path.service.PathService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/paths")
+public class PathController {
+    private final PathService pathService;
+
+    public PathController(PathService pathService){
+        this.pathService = pathService;
+    }
+
+    /*response 변경*/
+    @PostMapping("/search/path")
+    String searchPath(@RequestBody SearchPathRequest request){
+        return pathService.searchPath(request);
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/path/controller/PathController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/controller/PathController.java
@@ -2,6 +2,7 @@ package com.twtw.backend.domain.path.controller;
 
 import com.twtw.backend.domain.path.dto.client.SearchPathRequest;
 import com.twtw.backend.domain.path.service.PathService;
+
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -9,13 +10,13 @@ import org.springframework.web.bind.annotation.*;
 public class PathController {
     private final PathService pathService;
 
-    public PathController(PathService pathService){
+    public PathController(PathService pathService) {
         this.pathService = pathService;
     }
 
     /*response 변경*/
     @PostMapping("/search/path")
-    String searchPath(@RequestBody SearchPathRequest request){
+    String searchPath(@RequestBody SearchPathRequest request) {
         return pathService.searchPath(request);
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathFuel.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathFuel.java
@@ -1,0 +1,13 @@
+package com.twtw.backend.domain.path.dto.client;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SearchPathFuel {
+    GASOLINE("gasoline"),
+    HIGHGRADEGASOLINE("highgradegasoline"),
+    DIESEL("diesel"),
+    LPG("lpg");
+
+    private final String toSmall;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathOption.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathOption.java
@@ -4,16 +4,16 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum SearchPathOption {
-    TRAFAST("실시간 빠른길","trafast"),
-    TRACOMFORT("실시간 편한길","tracomfort"),
-    TRAOPTIONAL("실시간 최적","traoptional"),
-    TRAAVOIDTOLL("무료 우선","travoidtoll"),
-    TRAAVOIDCARONLY("자동차 전용도로 회피 우선","traavoidcaronly");
+    TRAFAST("실시간 빠른길", "trafast"),
+    TRACOMFORT("실시간 편한길", "tracomfort"),
+    TRAOPTIONAL("실시간 최적", "traoptional"),
+    TRAAVOIDTOLL("무료 우선", "travoidtoll"),
+    TRAAVOIDCARONLY("자동차 전용도로 회피 우선", "traavoidcaronly");
 
     private final String toKorean;
     private final String toSmall;
 
-    public String toSmallOption(){
+    public String toSmallOption() {
         return this.toSmall;
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathOption.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathOption.java
@@ -1,0 +1,19 @@
+package com.twtw.backend.domain.path.dto.client;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SearchPathOption {
+    TRAFAST("실시간 빠른길","trafast"),
+    TRACOMFORT("실시간 편한길","tracomfort"),
+    TRAOPTIONAL("실시간 최적","traoptional"),
+    TRAAVOIDTOLL("무료 우선","travoidtoll"),
+    TRAAVOIDCARONLY("자동차 전용도로 회피 우선","traavoidcaronly");
+
+    private final String toKorean;
+    private final String toSmall;
+
+    public String toSmallOption(){
+        return this.toSmall;
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathRequest.java
@@ -2,11 +2,10 @@ package com.twtw.backend.domain.path.dto.client;
 
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-
 
 @Getter
 @NoArgsConstructor
@@ -15,9 +14,12 @@ public class SearchPathRequest {
     String start;
     String end;
     String wayPoint;
+
     @Enumerated(value = EnumType.STRING)
     SearchPathOption option;
+
     String carType;
+
     @Enumerated(value = EnumType.STRING)
     SearchPathFuel fuelType;
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathRequest.java
@@ -1,0 +1,12 @@
+package com.twtw.backend.domain.path.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchPathRequest {
+
+}

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathRequest.java
@@ -1,12 +1,23 @@
 package com.twtw.backend.domain.path.dto.client;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class SearchPathRequest {
-
+    String start;
+    String end;
+    String wayPoint;
+    @Enumerated(value = EnumType.STRING)
+    SearchPathOption option;
+    String carType;
+    @Enumerated(value = EnumType.STRING)
+    SearchPathFuel fuelType;
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathResponse.java
@@ -1,0 +1,11 @@
+package com.twtw.backend.domain.path.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchPathResponse {
+}

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathResponse.java
@@ -4,8 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class SearchPathResponse {
+    int code;
+    String message;
+    String currentDateTime;
+
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/SearchPathResponse.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -12,5 +11,4 @@ public class SearchPathResponse {
     int code;
     String message;
     String currentDateTime;
-
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/service/PathService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/service/PathService.java
@@ -1,0 +1,7 @@
+package com.twtw.backend.domain.path.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PathService {
+}

--- a/backend/src/main/java/com/twtw/backend/domain/path/service/PathService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/service/PathService.java
@@ -3,18 +3,18 @@ package com.twtw.backend.domain.path.service;
 import com.twtw.backend.domain.path.dto.client.SearchPathRequest;
 import com.twtw.backend.domain.path.dto.client.SearchPathResponse;
 import com.twtw.backend.global.client.PathClient;
+
 import org.springframework.stereotype.Service;
 
 @Service
 public class PathService {
     private final PathClient<SearchPathRequest, SearchPathResponse> client;
 
-    PathService(PathClient<SearchPathRequest, SearchPathResponse> client){
+    PathService(PathClient<SearchPathRequest, SearchPathResponse> client) {
         this.client = client;
     }
 
-    public String searchPath(final SearchPathRequest request){
+    public String searchPath(final SearchPathRequest request) {
         return this.client.request(request);
     }
-
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/service/PathService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/service/PathService.java
@@ -1,7 +1,20 @@
 package com.twtw.backend.domain.path.service;
 
+import com.twtw.backend.domain.path.dto.client.SearchPathRequest;
+import com.twtw.backend.domain.path.dto.client.SearchPathResponse;
+import com.twtw.backend.global.client.PathClient;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PathService {
+    private final PathClient<SearchPathRequest, SearchPathResponse> client;
+
+    PathService(PathClient<SearchPathRequest, SearchPathResponse> client){
+        this.client = client;
+    }
+
+    public String searchPath(final SearchPathRequest request){
+        return this.client.request(request);
+    }
+
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
@@ -8,6 +8,7 @@ import com.twtw.backend.global.exception.WebClientResponseException;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -22,6 +23,7 @@ public class SearchDestinationClient
         implements MapClient<SearchDestinationRequest, SearchDestinationResponse> {
     private static final Integer MAX_SIZE_PER_REQUEST = 15;
     private static final Integer DEFAULT_DISTANCE_RADIUS = 20000;
+    @Qualifier("KakaoWebClient")
     private final WebClient webClient;
 
     @Override

--- a/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
@@ -23,6 +23,7 @@ public class SearchDestinationClient
         implements MapClient<SearchDestinationRequest, SearchDestinationResponse> {
     private static final Integer MAX_SIZE_PER_REQUEST = 15;
     private static final Integer DEFAULT_DISTANCE_RADIUS = 20000;
+
     @Qualifier("KakaoWebClient")
     private final WebClient webClient;
 

--- a/backend/src/main/java/com/twtw/backend/global/client/PathClient.java
+++ b/backend/src/main/java/com/twtw/backend/global/client/PathClient.java
@@ -1,0 +1,5 @@
+package com.twtw.backend.global.client;
+
+public interface PathClient<T, R>{
+
+}

--- a/backend/src/main/java/com/twtw/backend/global/client/PathClient.java
+++ b/backend/src/main/java/com/twtw/backend/global/client/PathClient.java
@@ -1,5 +1,5 @@
 package com.twtw.backend.global.client;
 
 public interface PathClient<T, R>{
-
+    public String request(T request);
 }

--- a/backend/src/main/java/com/twtw/backend/global/client/PathClient.java
+++ b/backend/src/main/java/com/twtw/backend/global/client/PathClient.java
@@ -1,5 +1,5 @@
 package com.twtw.backend.global.client;
 
-public interface PathClient<T, R>{
+public interface PathClient<T, R> {
     public String request(T request);
 }


### PR DESCRIPTION
## 추가/수정한 기능 설명
kakao 경로 API 문제점 : 경로에 대한 정보를 json으로 제공하지 않음 -> url 호출로 카카오 맵을 통해 확인 가능(별도로 카카오맵을 열어야 함)
naver maps api의 문제점 : 좌표에 대한 정보 제공이 부족 but 경로 제공 api가 json으로 제공

결론
기본적인 좌표에 대한 정보 제공 (목적지 , 주변 정보) - kakao api
경로 - naver api 

추가
경로 제공을 naver maps api 사용
https://api.ncloud-docs.com/docs/ai-naver-mapsdirections-driving#RequestPositionFormat

webClient의 분리
1. @Qualifier 어노테이션 사용하여 KakaoWebClient 와 NaverWebClient 분리

## 특이사항
테스트까지는 진행하지 않음 (기본적인 연동에 집중한 첫 번째 커밋)

## check list
- [x] issue number를 브랜치 앞에 추가 했나요?
- [X ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [O] 추가/수정사항을 설명했나요?
