### PR TITLE
[FEAT] RabbitMQ Queue, Exchange, Binding 생성 자동화

### DIFF
--- a/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
@@ -2,9 +2,7 @@ package com.twtw.backend.config.rabbitmq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twtw.backend.global.properties.RabbitMQProperties;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
@@ -12,6 +10,7 @@ import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
@@ -39,8 +38,23 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public Binding binding(final Queue queue, final TopicExchange exchange) {
-        return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
+    public Binding binding(final Queue queue, final TopicExchange topicExchange) {
+        return BindingBuilder.bind(queue).to(topicExchange).with(ROUTING_KEY);
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory factory = new CachingConnectionFactory();
+        factory.setHost(rabbitMQProperties.getHost());
+        factory.setPort(rabbitMQProperties.getPort());
+        factory.setUsername(rabbitMQProperties.getUsername());
+        factory.setPassword(rabbitMQProperties.getPassword());
+        return factory;
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter(objectMapper);
     }
 
     @Bean
@@ -52,16 +66,15 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public ConnectionFactory connectionFactory() {
-        CachingConnectionFactory factory = new CachingConnectionFactory();
-        factory.setHost(rabbitMQProperties.getHost());
-        factory.setUsername(rabbitMQProperties.getUsername());
-        factory.setPassword(rabbitMQProperties.getPassword());
-        return factory;
-    }
-
-    @Bean
-    public Jackson2JsonMessageConverter jsonMessageConverter() {
-        return new Jackson2JsonMessageConverter(objectMapper);
+    public RabbitAdmin rabbitAdmin(
+            final ConnectionFactory connectionFactory,
+            final Queue queue,
+            final TopicExchange topicExchange,
+            final Binding binding) {
+        final RabbitAdmin rabbitAdmin = new RabbitAdmin(connectionFactory);
+        rabbitAdmin.declareQueue(queue);
+        rabbitAdmin.declareExchange(topicExchange);
+        rabbitAdmin.declareBinding(binding);
+        return rabbitAdmin;
     }
 }

--- a/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
@@ -2,7 +2,9 @@ package com.twtw.backend.config.rabbitmq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twtw.backend.global.properties.RabbitMQProperties;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;


### PR DESCRIPTION
## 추가/수정한 기능 설명
- RabbitAdmin 빈 등록으로 생성 자동화

## 특이사항
- RabbitMQ가 켜진 상태에서 여러번 서버를 껐다 켜도 중복 생성 안됨

## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
