### PR TITLE
[FEAT] Feat/auth test

### DIFF
--- a/backend/src/main/java/com/twtw/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/twtw/backend/domain/member/repository/MemberRepository.java
@@ -18,5 +18,6 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     @Query(
             "SELECT m FROM Member m WHERE m.oauthInfo.clientId = :oAuthId AND"
                     + " m.oauthInfo.authType = :authType")
-    Optional<Member> findByOAuthIdAndAuthType(@Param("oAuthId") String oAuthId, @Param("authType") AuthType authType);
+    Optional<Member> findByOAuthIdAndAuthType(
+            @Param("oAuthId") String oAuthId, @Param("authType") AuthType authType);
 }

--- a/backend/src/main/java/com/twtw/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/twtw/backend/domain/member/repository/MemberRepository.java
@@ -5,6 +5,7 @@ import com.twtw.backend.domain.member.entity.Member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -17,5 +18,5 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     @Query(
             "SELECT m FROM Member m WHERE m.oauthInfo.clientId = :oAuthId AND"
                     + " m.oauthInfo.authType = :authType")
-    Optional<Member> findByOAuthIdAndAuthType(String oAuthId, AuthType authType);
+    Optional<Member> findByOAuthIdAndAuthType(@Param("oAuthId") String oAuthId, @Param("authType") AuthType authType);
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/car/Position.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/car/Position.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Position {
-    Double x;
-    Double y;
+    private Double x;
+    private Double y;
 }

--- a/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
@@ -1,0 +1,66 @@
+package com.twtw.backend.domain.member.service;
+
+import com.twtw.backend.domain.member.dto.request.MemberSaveRequest;
+import com.twtw.backend.domain.member.dto.request.OAuthRequest;
+import com.twtw.backend.domain.member.dto.response.AfterLoginResponse;
+import com.twtw.backend.domain.member.entity.AuthStatus;
+import com.twtw.backend.domain.member.entity.AuthType;
+import com.twtw.backend.domain.member.repository.MemberRepository;
+import com.twtw.backend.domain.member.repository.RefreshTokenRepository;
+import com.twtw.backend.support.database.DatabaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DatabaseTest
+@DisplayName("AuthService의")
+public class AuthServiceTest {
+
+    @Autowired private AuthService authService;
+
+    @Autowired private MemberRepository memberRepository;
+
+    @Autowired private RefreshTokenRepository refreshTokenRepository;
+
+
+    @Test
+    @DisplayName("Kakao 회원 가입이 수행되는가")
+    void saveMemberKakao(){
+        // given
+        MemberSaveRequest kakaoRequest = new MemberSaveRequest(
+                "JinJooWon_Kakao",
+                "TEST_PROFILE_IMAGE",
+                new OAuthRequest(
+                       "TEST_KAKAO_TOKEN",
+                       AuthType.KAKAO
+                )
+        );
+        // when
+        AfterLoginResponse response = authService.saveMember(kakaoRequest);
+        // then
+        assertThat(response.getStatus().equals(AuthStatus.SIGNIN));
+    }
+
+    @Test
+    @DisplayName("Apple 회원 가입이 수행되는가")
+    void saveMemberApple(){
+        //given
+        MemberSaveRequest appleRequest = new MemberSaveRequest(
+                "JinJooWon_Apple",
+                "TEST_PROFILE_IMAGE",
+                new OAuthRequest(
+                        "TEST_APPLE_TOKEN",
+                        AuthType.APPLE
+                )
+        );
+        // when
+        AfterLoginResponse response = authService.saveMember(appleRequest);
+        // then
+        assertThat(response.getStatus().equals(AuthStatus.SIGNIN));
+    }
+
+
+}

--- a/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
@@ -5,8 +5,10 @@ import com.twtw.backend.domain.member.dto.request.OAuthRequest;
 import com.twtw.backend.domain.member.dto.response.AfterLoginResponse;
 import com.twtw.backend.domain.member.entity.AuthStatus;
 import com.twtw.backend.domain.member.entity.AuthType;
+import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.member.repository.MemberRepository;
 import com.twtw.backend.domain.member.repository.RefreshTokenRepository;
+import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.database.DatabaseTest;
 import org.junit.jupiter.api.DisplayName;
 
@@ -16,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DatabaseTest
-@DisplayName("AuthService의")
+@DisplayName("AuthService의 ")
 public class AuthServiceTest {
 
     @Autowired private AuthService authService;
@@ -62,5 +64,21 @@ public class AuthServiceTest {
         assertThat(response.getStatus().equals(AuthStatus.SIGNIN));
     }
 
+    @Test
+    @DisplayName("로그인 후 회원에 대해 토큰이 재발급되는가")
+    void getTokenByOAuthSuccess(){
+        // given
+        final Member member = memberRepository.save(MemberEntityFixture.FIRST_MEMBER.toEntity());
 
+        final OAuthRequest request = new OAuthRequest(
+                member.getOauthInfo().getClientId(),
+                member.getOauthInfo().getAuthType()
+        );
+
+        // when
+        AfterLoginResponse response = authService.getTokenByOAuth(request);
+
+        // then
+        assertThat(response.getStatus().equals(AuthStatus.SIGNIN));
+    }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
@@ -10,6 +10,7 @@ import com.twtw.backend.domain.member.repository.MemberRepository;
 import com.twtw.backend.domain.member.repository.RefreshTokenRepository;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.database.DatabaseTest;
+import com.twtw.backend.support.exclude.ExcludeTest;
 import org.junit.jupiter.api.DisplayName;
 
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DatabaseTest
 @DisplayName("AuthService의 ")
-public class AuthServiceTest {
+public class AuthServiceTest extends ExcludeTest {
 
     @Autowired private AuthService authService;
 
@@ -40,10 +41,12 @@ public class AuthServiceTest {
                        AuthType.KAKAO
                 )
         );
+
         // when
         AfterLoginResponse response = authService.saveMember(kakaoRequest);
+
         // then
-        assertThat(response.getStatus().equals(AuthStatus.SIGNIN));
+        assertThat(response.getStatus().equals(AuthStatus.SIGNIN)).isTrue();
     }
 
     @Test
@@ -58,10 +61,12 @@ public class AuthServiceTest {
                         AuthType.APPLE
                 )
         );
+
         // when
         AfterLoginResponse response = authService.saveMember(appleRequest);
+
         // then
-        assertThat(response.getStatus().equals(AuthStatus.SIGNIN));
+        assertThat(response.getStatus().equals(AuthStatus.SIGNIN)).isTrue();
     }
 
     @Test
@@ -79,6 +84,6 @@ public class AuthServiceTest {
         AfterLoginResponse response = authService.getTokenByOAuth(request);
 
         // then
-        assertThat(response.getStatus().equals(AuthStatus.SIGNIN));
+        assertThat(response.getStatus().equals(AuthStatus.SIGNIN)).isTrue();
     }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
@@ -1,5 +1,7 @@
 package com.twtw.backend.domain.member.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.twtw.backend.domain.member.dto.request.MemberSaveRequest;
 import com.twtw.backend.domain.member.dto.request.OAuthRequest;
 import com.twtw.backend.domain.member.dto.response.AfterLoginResponse;
@@ -11,12 +13,10 @@ import com.twtw.backend.domain.member.repository.RefreshTokenRepository;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.database.DatabaseTest;
 import com.twtw.backend.support.exclude.ExcludeTest;
-import org.junit.jupiter.api.DisplayName;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DatabaseTest
 @DisplayName("AuthService의 ")
@@ -28,19 +28,15 @@ public class AuthServiceTest extends ExcludeTest {
 
     @Autowired private RefreshTokenRepository refreshTokenRepository;
 
-
     @Test
     @DisplayName("Kakao 회원 가입이 수행되는가")
-    void saveMemberKakao(){
+    void saveMemberKakao() {
         // given
-        MemberSaveRequest kakaoRequest = new MemberSaveRequest(
-                "JinJooWon_Kakao",
-                "TEST_PROFILE_IMAGE",
-                new OAuthRequest(
-                       "TEST_KAKAO_TOKEN",
-                       AuthType.KAKAO
-                )
-        );
+        MemberSaveRequest kakaoRequest =
+                new MemberSaveRequest(
+                        "JinJooWon_Kakao",
+                        "TEST_PROFILE_IMAGE",
+                        new OAuthRequest("TEST_KAKAO_TOKEN", AuthType.KAKAO));
 
         // when
         AfterLoginResponse response = authService.saveMember(kakaoRequest);
@@ -51,16 +47,13 @@ public class AuthServiceTest extends ExcludeTest {
 
     @Test
     @DisplayName("Apple 회원 가입이 수행되는가")
-    void saveMemberApple(){
-        //given
-        MemberSaveRequest appleRequest = new MemberSaveRequest(
-                "JinJooWon_Apple",
-                "TEST_PROFILE_IMAGE",
-                new OAuthRequest(
-                        "TEST_APPLE_TOKEN",
-                        AuthType.APPLE
-                )
-        );
+    void saveMemberApple() {
+        // given
+        MemberSaveRequest appleRequest =
+                new MemberSaveRequest(
+                        "JinJooWon_Apple",
+                        "TEST_PROFILE_IMAGE",
+                        new OAuthRequest("TEST_APPLE_TOKEN", AuthType.APPLE));
 
         // when
         AfterLoginResponse response = authService.saveMember(appleRequest);
@@ -71,14 +64,13 @@ public class AuthServiceTest extends ExcludeTest {
 
     @Test
     @DisplayName("로그인 후 회원에 대해 토큰이 재발급되는가")
-    void getTokenByOAuthSuccess(){
+    void getTokenByOAuthSuccess() {
         // given
         final Member member = memberRepository.save(MemberEntityFixture.FIRST_MEMBER.toEntity());
 
-        final OAuthRequest request = new OAuthRequest(
-                member.getOauthInfo().getClientId(),
-                member.getOauthInfo().getAuthType()
-        );
+        final OAuthRequest request =
+                new OAuthRequest(
+                        member.getOauthInfo().getClientId(), member.getOauthInfo().getAuthType());
 
         // when
         AfterLoginResponse response = authService.getTokenByOAuth(request);

--- a/backend/src/test/java/com/twtw/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/member/service/MemberServiceTest.java
@@ -55,4 +55,6 @@ class MemberServiceTest extends LoginTest {
         // then
         assertThat(memberResponse.getId()).isEqualTo(member.getId());
     }
+
+
 }

--- a/backend/src/test/java/com/twtw/backend/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/member/service/MemberServiceTest.java
@@ -55,6 +55,4 @@ class MemberServiceTest extends LoginTest {
         // then
         assertThat(memberResponse.getId()).isEqualTo(member.getId());
     }
-
-
 }


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. AuthService의 saveMember(회원가입) 테스트를 Kakao , Apple 사용자 분리하여 구현
2. 등록된 회원에 대해 로그인 후 토큰이 발급되는가 테스트

## 특이사항


## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
