### PR TITLE
[FEAT] cache external api

### DIFF
--- a/backend/src/main/java/com/twtw/backend/domain/path/controller/PathController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/controller/PathController.java
@@ -8,6 +8,7 @@ import com.twtw.backend.domain.path.service.PathService;
 
 import jakarta.validation.Valid;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,12 +22,14 @@ public class PathController {
     }
 
     @PostMapping("/search/car")
+    @Cacheable(value = "carPath", key = "{#request}", cacheManager = "cacheManager", unless = "result.body.code != 0")
     public ResponseEntity<SearchCarPathResponse> searchCarPath(
             @RequestBody @Valid SearchCarPathRequest request) {
         return ResponseEntity.ok(pathService.searchCarPath(request));
     }
 
     @PostMapping("/search/ped")
+    @Cacheable(value = "pedPath", key = "{#request}", cacheManager = "cacheManager", unless = "result.body.features.size() <= 0")
     public ResponseEntity<SearchPedPathResponse> searchPedPath(
             @RequestBody @Valid SearchPedPathRequest request) {
         return ResponseEntity.ok(pathService.searchPedPath(request));

--- a/backend/src/main/java/com/twtw/backend/domain/path/controller/PathController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/controller/PathController.java
@@ -22,14 +22,22 @@ public class PathController {
     }
 
     @PostMapping("/search/car")
-    @Cacheable(value = "carPath", key = "{#request}", cacheManager = "cacheManager", unless = "result.body.code != 0")
+    @Cacheable(
+            value = "carPath",
+            key = "{#request}",
+            cacheManager = "cacheManager",
+            unless = "result.body.code != 0")
     public ResponseEntity<SearchCarPathResponse> searchCarPath(
             @RequestBody @Valid SearchCarPathRequest request) {
         return ResponseEntity.ok(pathService.searchCarPath(request));
     }
 
     @PostMapping("/search/ped")
-    @Cacheable(value = "pedPath", key = "{#request}", cacheManager = "cacheManager", unless = "result.body.features.size() <= 0")
+    @Cacheable(
+            value = "pedPath",
+            key = "{#request}",
+            cacheManager = "cacheManager",
+            unless = "result.body.features.size() <= 0")
     public ResponseEntity<SearchPedPathResponse> searchPedPath(
             @RequestBody @Valid SearchPedPathRequest request) {
         return ResponseEntity.ok(pathService.searchPedPath(request));

--- a/backend/src/main/java/com/twtw/backend/domain/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/place/controller/PlaceController.java
@@ -6,6 +6,7 @@ import com.twtw.backend.domain.place.service.PlaceService;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -19,6 +20,7 @@ public class PlaceController {
     private final PlaceService placeService;
 
     @GetMapping("surround")
+    @Cacheable(value = "surroundPlace", key = "{#surroundPlaceRequest}", cacheManager = "cacheManager", unless = "result.body.results.size() <= 0")
     public ResponseEntity<PlaceResponse> searchSurroundPlace(
             @ModelAttribute final SurroundPlaceRequest surroundPlaceRequest) {
         return ResponseEntity.ok(placeService.searchSurroundPlace(surroundPlaceRequest));

--- a/backend/src/main/java/com/twtw/backend/domain/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/place/controller/PlaceController.java
@@ -20,7 +20,11 @@ public class PlaceController {
     private final PlaceService placeService;
 
     @GetMapping("surround")
-    @Cacheable(value = "surroundPlace", key = "{#surroundPlaceRequest}", cacheManager = "cacheManager", unless = "result.body.results.size() <= 0")
+    @Cacheable(
+            value = "surroundPlace",
+            key = "{#surroundPlaceRequest}",
+            cacheManager = "cacheManager",
+            unless = "result.body.results.size() <= 0")
     public ResponseEntity<PlaceResponse> searchSurroundPlace(
             @ModelAttribute final SurroundPlaceRequest surroundPlaceRequest) {
         return ResponseEntity.ok(placeService.searchSurroundPlace(surroundPlaceRequest));

--- a/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
@@ -23,7 +23,11 @@ public class PlanController {
     private final PlanService planService;
 
     @GetMapping("search/destination")
-    @Cacheable(value = "planDestination", key = "{#request}", cacheManager = "cacheManager", unless = "result.body.results.size() <= 0")
+    @Cacheable(
+            value = "planDestination",
+            key = "{#request}",
+            cacheManager = "cacheManager",
+            unless = "result.body.results.size() <= 0")
     public ResponseEntity<PlanDestinationResponse> searchPlanDestination(
             @ModelAttribute final SearchDestinationRequest request) {
         return ResponseEntity.ok(planService.searchPlanDestination(request));

--- a/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
@@ -10,6 +10,7 @@ import com.twtw.backend.domain.plan.service.PlanService;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +23,7 @@ public class PlanController {
     private final PlanService planService;
 
     @GetMapping("search/destination")
+    @Cacheable(value = "planDestination", key = "{#request}", cacheManager = "cacheManager", unless = "result.body.results.size() <= 0")
     public ResponseEntity<PlanDestinationResponse> searchPlanDestination(
             @ModelAttribute final SearchDestinationRequest request) {
         return ResponseEntity.ok(planService.searchPlanDestination(request));


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 외부 API 캐싱 적용

## 특이사항
- ttl 1 hour로 설정
- response의 정보가 비어있지 않으면 캐싱하도록 설정

## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
