### PR TITLE
[FEAT] 누락된 api 구현

### DIFF
--- a/backend/src/docs/group.adoc
+++ b/backend/src/docs/group.adoc
@@ -28,3 +28,9 @@ operation::get share[snippets='http-request,http-response']
 
 === 자신의 소속 그룹 정보 반환
 operation::get myGroups[snippets='http-request,http-response']
+
+=== 그룹 자신 위치 수정
+operation::post update group member location[snippets='http-request,http-response']
+
+=== 그룹 탈퇴
+operation::post out group[snippets='http-request,http-response']

--- a/backend/src/docs/plan.adoc
+++ b/backend/src/docs/plan.adoc
@@ -25,3 +25,6 @@ operation::post out plan[snippets='http-request,http-response']
 
 === 본인이 속한 계획 전체 조회
 operation::get all plans[snippets='http-request,http-response']
+
+=== 본인이 속한 계획 전체 조회
+operation::post update plan[snippets='http-request,http-response']

--- a/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
@@ -35,11 +35,8 @@ public class SecurityConfig {
                                                 "auth/save",
                                                 "auth/login",
                                                 "member/duplicate/**",
-                                                "plan/**",
                                                 "actuator/**")
                                         .permitAll())
-                .authorizeHttpRequests(
-                        x -> x.requestMatchers("/test/**").permitAll().anyRequest().authenticated())
                 .sessionManagement(x -> x.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(

--- a/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
@@ -75,7 +75,7 @@ public class GroupController {
         return ResponseEntity.ok(groupService.getMyGroups());
     }
 
-    @PostMapping("/location")
+    @PostMapping("location")
     public ResponseEntity<Void> updateLocation(
             @RequestBody final UpdateLocationRequest updateLocationRequest) {
         groupService.updateLocation(updateLocationRequest);

--- a/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
@@ -3,16 +3,21 @@ package com.twtw.backend.domain.group.controller;
 import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
 import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
 import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
+import com.twtw.backend.domain.group.dto.request.OutGroupRequest;
+import com.twtw.backend.domain.group.dto.request.UpdateLocationRequest;
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/group")
@@ -66,5 +71,17 @@ public class GroupController {
     @GetMapping
     public ResponseEntity<List<GroupInfoResponse>> getMyGroups() {
         return ResponseEntity.ok(groupService.getMyGroups());
+    }
+
+    @PostMapping("/location")
+    public ResponseEntity<Void> updateLocation(@RequestBody final UpdateLocationRequest updateLocationRequest) {
+        groupService.updateLocation(updateLocationRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("out")
+    public ResponseEntity<Void> outGroup(@RequestBody final OutGroupRequest outGroupRequest) {
+        groupService.outGroup(outGroupRequest);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
@@ -9,8 +9,7 @@ import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
-import java.util.List;
-import java.util.UUID;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +17,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/group")
@@ -74,7 +76,8 @@ public class GroupController {
     }
 
     @PostMapping("/location")
-    public ResponseEntity<Void> updateLocation(@RequestBody final UpdateLocationRequest updateLocationRequest) {
+    public ResponseEntity<Void> updateLocation(
+            @RequestBody final UpdateLocationRequest updateLocationRequest) {
         groupService.updateLocation(updateLocationRequest);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/twtw/backend/domain/group/controller/advice/GroupControllerAdvice.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/controller/advice/GroupControllerAdvice.java
@@ -2,6 +2,7 @@ package com.twtw.backend.domain.group.controller.advice;
 
 import com.twtw.backend.domain.group.exception.IllegalGroupMemberException;
 import com.twtw.backend.global.advice.ErrorResponse;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/backend/src/main/java/com/twtw/backend/domain/group/controller/advice/GroupControllerAdvice.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/controller/advice/GroupControllerAdvice.java
@@ -1,0 +1,18 @@
+package com.twtw.backend.domain.group.controller.advice;
+
+import com.twtw.backend.domain.group.exception.IllegalGroupMemberException;
+import com.twtw.backend.global.advice.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GroupControllerAdvice {
+
+    @ExceptionHandler(IllegalGroupMemberException.class)
+    public ResponseEntity<ErrorResponse> invalidFriendMember(final IllegalGroupMemberException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(e.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/group/dto/request/OutGroupRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/dto/request/OutGroupRequest.java
@@ -1,0 +1,13 @@
+package com.twtw.backend.domain.group.dto.request;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutGroupRequest {
+    private UUID groupId;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/group/dto/request/OutGroupRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/dto/request/OutGroupRequest.java
@@ -1,9 +1,10 @@
 package com.twtw.backend.domain.group.dto.request;
 
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/twtw/backend/domain/group/dto/request/UpdateLocationRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/dto/request/UpdateLocationRequest.java
@@ -1,0 +1,15 @@
+package com.twtw.backend.domain.group.dto.request;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateLocationRequest {
+    private UUID groupId;
+    private Double longitude;
+    private Double latitude;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/group/dto/request/UpdateLocationRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/dto/request/UpdateLocationRequest.java
@@ -1,9 +1,10 @@
 package com.twtw.backend.domain.group.dto.request;
 
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/twtw/backend/domain/group/entity/Group.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/entity/Group.java
@@ -1,5 +1,6 @@
 package com.twtw.backend.domain.group.entity;
 
+import com.twtw.backend.domain.group.exception.IllegalGroupMemberException;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.plan.entity.Plan;
 import com.twtw.backend.global.audit.AuditListener;
@@ -74,5 +75,28 @@ public class Group implements Auditable {
 
     private boolean addGroupMember(final GroupMember groupMember) {
         return this.groupMembers.add(groupMember);
+    }
+
+    public void updateMemberLocation(final Member member, final Double longitude, final Double latitude) {
+        final GroupMember groupMember = getGroupMember(member);
+        groupMember.updateCoordinate(longitude, latitude);
+    }
+
+    private GroupMember getGroupMember(final Member member) {
+        return this.groupMembers.stream()
+                .filter(groupMember -> groupMember.isSameMember(member))
+                .findAny()
+                .orElseThrow(IllegalGroupMemberException::new);
+    }
+
+    public void outGroup(final Member member) {
+        this.groupMembers.removeIf(groupMember -> groupMember.isSameMember(member));
+        if (hasNoLeader()) {
+            this.leaderId = this.groupMembers.get(0).getMember().getId();
+        }
+    }
+
+    private boolean hasNoLeader() {
+        return this.groupMembers.stream().noneMatch(GroupMember::isLeader);
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/group/entity/Group.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/entity/Group.java
@@ -77,7 +77,8 @@ public class Group implements Auditable {
         return this.groupMembers.add(groupMember);
     }
 
-    public void updateMemberLocation(final Member member, final Double longitude, final Double latitude) {
+    public void updateMemberLocation(
+            final Member member, final Double longitude, final Double latitude) {
         final GroupMember groupMember = getGroupMember(member);
         groupMember.updateCoordinate(longitude, latitude);
     }

--- a/backend/src/main/java/com/twtw/backend/domain/group/entity/GroupMember.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/entity/GroupMember.java
@@ -1,10 +1,10 @@
 package com.twtw.backend.domain.group.entity;
 
 import com.twtw.backend.domain.member.entity.Member;
+import com.twtw.backend.domain.place.entity.Coordinate;
 import com.twtw.backend.global.audit.AuditListener;
 import com.twtw.backend.global.audit.Auditable;
 import com.twtw.backend.global.audit.BaseTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -15,15 +15,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
 import org.hibernate.annotations.Where;
-
-import java.util.UUID;
 
 @Entity
 @Getter
@@ -31,6 +28,7 @@ import java.util.UUID;
 @EntityListeners(AuditListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupMember implements Auditable {
+
     @Id
     @GeneratedValue(generator = "uuid2")
     @Column(name = "id", columnDefinition = "BINARY(16)")
@@ -43,6 +41,9 @@ public class GroupMember implements Auditable {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Embedded
+    private Coordinate coordinate;
 
     private Boolean share;
 
@@ -76,5 +77,26 @@ public class GroupMember implements Auditable {
 
     public UUID getGroupId() {
         return this.group.getId();
+    }
+
+    public Coordinate getCoordinate() {
+        if (share) {
+            return coordinate;
+        }
+        return Coordinate.empty();
+    }
+
+    public void updateCoordinate(final Double longitude, final Double latitude) {
+        if (share) {
+            this.coordinate = new Coordinate(longitude, latitude);
+        }
+    }
+
+    public boolean isSameMember(final Member member) {
+        return this.member.getId().equals(member.getId());
+    }
+
+    public boolean isLeader() {
+        return this.group.getLeaderId().equals(this.member.getId());
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/group/entity/GroupMember.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/entity/GroupMember.java
@@ -5,6 +5,7 @@ import com.twtw.backend.domain.place.entity.Coordinate;
 import com.twtw.backend.global.audit.AuditListener;
 import com.twtw.backend.global.audit.Auditable;
 import com.twtw.backend.global.audit.BaseTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -15,12 +16,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.util.UUID;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import org.hibernate.annotations.Where;
+
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -42,8 +46,7 @@ public class GroupMember implements Auditable {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Embedded
-    private Coordinate coordinate;
+    @Embedded private Coordinate coordinate;
 
     private Boolean share;
 

--- a/backend/src/main/java/com/twtw/backend/domain/group/exception/IllegalGroupMemberException.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/exception/IllegalGroupMemberException.java
@@ -1,0 +1,10 @@
+package com.twtw.backend.domain.group.exception;
+
+public class IllegalGroupMemberException extends IllegalArgumentException {
+
+    private static final String MESSAGE = "그룹에 포함되지 않은 멤버입니다.";
+
+    public IllegalGroupMemberException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/group/service/GroupService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/service/GroupService.java
@@ -3,6 +3,8 @@ package com.twtw.backend.domain.group.service;
 import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
 import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
 import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
+import com.twtw.backend.domain.group.dto.request.OutGroupRequest;
+import com.twtw.backend.domain.group.dto.request.UpdateLocationRequest;
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
@@ -130,5 +132,19 @@ public class GroupService {
         }
 
         return groupMapper.toMyGroupsInfo(loginMember.getGroupMembers());
+    }
+
+    @Transactional
+    public void updateLocation(final UpdateLocationRequest updateLocationRequest) {
+        final Member member = authService.getMemberByJwt();
+        final Group group = getGroupEntity(updateLocationRequest.getGroupId());
+        group.updateMemberLocation(member, updateLocationRequest.getLongitude(), updateLocationRequest.getLatitude());
+    }
+
+    @Transactional
+    public void outGroup(final OutGroupRequest outGroupRequest) {
+        final Member member = authService.getMemberByJwt();
+        final Group group = getGroupEntity(outGroupRequest.getGroupId());
+        group.outGroup(member);
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/group/service/GroupService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/service/GroupService.java
@@ -138,7 +138,8 @@ public class GroupService {
     public void updateLocation(final UpdateLocationRequest updateLocationRequest) {
         final Member member = authService.getMemberByJwt();
         final Group group = getGroupEntity(updateLocationRequest.getGroupId());
-        group.updateMemberLocation(member, updateLocationRequest.getLongitude(), updateLocationRequest.getLatitude());
+        group.updateMemberLocation(
+                member, updateLocationRequest.getLongitude(), updateLocationRequest.getLatitude());
     }
 
     @Transactional

--- a/backend/src/main/java/com/twtw/backend/domain/location/controller/LocationController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/controller/LocationController.java
@@ -27,6 +27,6 @@ public class LocationController {
             @DestinationVariable final UUID planId,
             @Payload final LocationRequest locationRequest) {
         rabbitTemplate.convertAndSend(
-                EXCHANGE_NAME, ROUTING_KEY + planId, locationService.addInfo(locationRequest));
+                EXCHANGE_NAME, ROUTING_KEY + planId, locationService.addInfo(planId, locationRequest));
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/location/controller/LocationController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/controller/LocationController.java
@@ -27,6 +27,8 @@ public class LocationController {
             @DestinationVariable final UUID planId,
             @Payload final LocationRequest locationRequest) {
         rabbitTemplate.convertAndSend(
-                EXCHANGE_NAME, ROUTING_KEY + planId, locationService.addInfo(planId, locationRequest));
+                EXCHANGE_NAME,
+                ROUTING_KEY + planId,
+                locationService.addInfo(planId, locationRequest));
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/location/dto/response/AverageCoordinate.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/dto/response/AverageCoordinate.java
@@ -3,16 +3,14 @@ package com.twtw.backend.domain.location.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
-public class LocationResponse {
-    private String nickname;
+public class AverageCoordinate {
     private Double longitude;
     private Double latitude;
-    private AverageCoordinate averageCoordinate;
-    private LocalDateTime time;
+    private Double distance;
 }

--- a/backend/src/main/java/com/twtw/backend/domain/location/mapper/LocationMapper.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/mapper/LocationMapper.java
@@ -1,14 +1,13 @@
 package com.twtw.backend.domain.location.mapper;
 
 import com.twtw.backend.domain.location.dto.request.LocationRequest;
+import com.twtw.backend.domain.location.dto.response.AverageCoordinate;
 import com.twtw.backend.domain.location.dto.response.LocationResponse;
-
+import java.time.LocalDateTime;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 
-import java.time.LocalDateTime;
-
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface LocationMapper {
-    LocationResponse toResponse(LocationRequest locationRequest, LocalDateTime time);
+    LocationResponse toResponse(LocationRequest locationRequest, AverageCoordinate averageCoordinate, LocalDateTime time);
 }

--- a/backend/src/main/java/com/twtw/backend/domain/location/mapper/LocationMapper.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/mapper/LocationMapper.java
@@ -3,11 +3,16 @@ package com.twtw.backend.domain.location.mapper;
 import com.twtw.backend.domain.location.dto.request.LocationRequest;
 import com.twtw.backend.domain.location.dto.response.AverageCoordinate;
 import com.twtw.backend.domain.location.dto.response.LocationResponse;
-import java.time.LocalDateTime;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 
+import java.time.LocalDateTime;
+
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface LocationMapper {
-    LocationResponse toResponse(LocationRequest locationRequest, AverageCoordinate averageCoordinate, LocalDateTime time);
+    LocationResponse toResponse(
+            LocationRequest locationRequest,
+            AverageCoordinate averageCoordinate,
+            LocalDateTime time);
 }

--- a/backend/src/main/java/com/twtw/backend/domain/location/mapper/LocationMapper.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/mapper/LocationMapper.java
@@ -5,12 +5,15 @@ import com.twtw.backend.domain.location.dto.response.AverageCoordinate;
 import com.twtw.backend.domain.location.dto.response.LocationResponse;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
 import java.time.LocalDateTime;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface LocationMapper {
+    @Mapping(target = "longitude", source = "locationRequest.longitude")
+    @Mapping(target = "latitude", source = "locationRequest.latitude")
     LocationResponse toResponse(
             LocationRequest locationRequest,
             AverageCoordinate averageCoordinate,

--- a/backend/src/main/java/com/twtw/backend/domain/location/service/GeoService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/service/GeoService.java
@@ -1,0 +1,93 @@
+package com.twtw.backend.domain.location.service;
+
+import com.twtw.backend.domain.location.dto.request.LocationRequest;
+import com.twtw.backend.domain.location.dto.response.AverageCoordinate;
+import com.twtw.backend.domain.member.entity.Member;
+import com.twtw.backend.domain.plan.entity.Plan;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.GeoResult;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GeoService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public AverageCoordinate saveLocation(final Plan plan, final Member member, final LocationRequest locationRequest) {
+        final String planId = plan.getId().toString();
+
+        redisTemplate.opsForGeo().add(
+                planId,
+                new Point(locationRequest.getLongitude(), locationRequest.getLatitude()),
+                member.getId().toString());
+
+        return calculate(planId, locationRequest);
+    }
+
+    private AverageCoordinate calculate(final String planId, final LocationRequest locationRequest) {
+        final Double userLongitude = locationRequest.getLongitude();
+        final Double userLatitude = locationRequest.getLatitude();
+
+        GeoResults<GeoLocation<String>> geoResults = redisTemplate.opsForGeo()
+                .radius(planId, new Circle(new Point(userLongitude, userLatitude), new Distance(0, Metrics.KILOMETERS)));
+
+        if (geoResults == null) {
+            return new AverageCoordinate();
+        }
+
+        final List<GeoResult<GeoLocation<String>>> content = geoResults.getContent();
+
+        if (content.isEmpty()) {
+            return new AverageCoordinate();
+        }
+
+        return calculateAverage(content, userLatitude, userLongitude);
+    }
+
+    private AverageCoordinate calculateAverage(
+            final List<GeoResult<GeoLocation<String>>> content,
+            final Double userLatitude,
+            final Double userLongitude) {
+
+        double totalLatitude = 0.0;
+        double totalLongitude = 0.0;
+
+        for (GeoResult<GeoLocation<String>> geoResult : content) {
+            Point point = geoResult.getContent().getPoint();
+            totalLatitude += point.getY();
+            totalLongitude += point.getX();
+        }
+
+        final int size = content.size();
+        double avgLatitude = totalLatitude / size;
+        double avgLongitude = totalLongitude / size;
+
+        final Double distance = distance(userLatitude, userLongitude, avgLatitude, avgLongitude);
+
+        return new AverageCoordinate(avgLongitude, avgLatitude, distance);
+    }
+
+    private Double distance(final Double lat1, final Double lon1, final Double lat2, final Double lon2) {
+        int radius = 6371;
+
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return radius * c;
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/location/service/LocationService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/service/LocationService.java
@@ -1,22 +1,36 @@
 package com.twtw.backend.domain.location.service;
 
 import com.twtw.backend.domain.location.dto.request.LocationRequest;
+import com.twtw.backend.domain.location.dto.response.AverageCoordinate;
 import com.twtw.backend.domain.location.dto.response.LocationResponse;
 import com.twtw.backend.domain.location.mapper.LocationMapper;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-
+import com.twtw.backend.domain.member.entity.Member;
+import com.twtw.backend.domain.member.service.AuthService;
+import com.twtw.backend.domain.plan.entity.Plan;
+import com.twtw.backend.domain.plan.service.PlanService;
 import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class LocationService {
 
     private final LocationMapper locationMapper;
+    private final AuthService authService;
+    private final PlanService planService;
+    private final GeoService geoService;
 
-    public LocationResponse addInfo(final LocationRequest locationRequest) {
-        return locationMapper.toResponse(locationRequest, LocalDateTime.now());
+    @Transactional
+    public LocationResponse addInfo(final UUID planId, final LocationRequest locationRequest) {
+        final Member member = authService.getMemberByJwt();
+        final Plan plan = planService.getPlanEntity(planId);
+        plan.updateMemberLocation(member, locationRequest.getLongitude(), locationRequest.getLatitude());
+
+        final AverageCoordinate averageCoordinate = geoService.saveLocation(plan, member, locationRequest);
+
+        return locationMapper.toResponse(locationRequest, averageCoordinate, LocalDateTime.now());
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/location/service/LocationService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/service/LocationService.java
@@ -8,11 +8,14 @@ import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.member.service.AuthService;
 import com.twtw.backend.domain.plan.entity.Plan;
 import com.twtw.backend.domain.plan.service.PlanService;
-import java.time.LocalDateTime;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -27,9 +30,11 @@ public class LocationService {
     public LocationResponse addInfo(final UUID planId, final LocationRequest locationRequest) {
         final Member member = authService.getMemberByJwt();
         final Plan plan = planService.getPlanEntity(planId);
-        plan.updateMemberLocation(member, locationRequest.getLongitude(), locationRequest.getLatitude());
+        plan.updateMemberLocation(
+                member, locationRequest.getLongitude(), locationRequest.getLatitude());
 
-        final AverageCoordinate averageCoordinate = geoService.saveLocation(plan, member, locationRequest);
+        final AverageCoordinate averageCoordinate =
+                geoService.saveLocation(plan, member, locationRequest);
 
         return locationMapper.toResponse(locationRequest, averageCoordinate, LocalDateTime.now());
     }

--- a/backend/src/main/java/com/twtw/backend/domain/place/entity/Coordinate.java
+++ b/backend/src/main/java/com/twtw/backend/domain/place/entity/Coordinate.java
@@ -10,6 +10,12 @@ import lombok.*;
 @EqualsAndHashCode(of = {"longitude", "latitude"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Coordinate {
+
+    private static final Coordinate EMPTY_INSTANCE = new Coordinate();
     private Double longitude;
     private Double latitude;
+
+    public static Coordinate empty() {
+        return EMPTY_INSTANCE;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/twtw/backend/domain/place/entity/Place.java
@@ -62,4 +62,18 @@ public class Place implements Auditable {
         this.roadAddressName = roadAddressName;
         this.coordinate = new Coordinate(longitude, latitude);
     }
+
+    public void update(
+            final String placeName,
+            final String placeUrl,
+            final CategoryGroupCode categoryGroupCode,
+            final String roadAddressName,
+            final Double longitude,
+            final Double latitude) {
+        this.placeName = placeName;
+        this.placeUrl = placeUrl;
+        this.categoryGroupCode = categoryGroupCode;
+        this.roadAddressName = roadAddressName;
+        this.coordinate = new Coordinate(longitude, latitude);
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/place/mapper/PlaceMapper.java
+++ b/backend/src/main/java/com/twtw/backend/domain/place/mapper/PlaceMapper.java
@@ -13,7 +13,7 @@ public interface PlaceMapper {
 
     Place toEntity(PlaceDetails detail);
 
-    @Mapping(target = "longitude", source = "coordinate.longitude")
-    @Mapping(target = "latitude", source = "coordinate.latitude")
+    @Mapping(target = "x", source = "coordinate.longitude")
+    @Mapping(target = "y", source = "coordinate.latitude")
     PlaceClientDetails toPlaceResponse(Place place);
 }

--- a/backend/src/main/java/com/twtw/backend/domain/place/mapper/PlaceMapper.java
+++ b/backend/src/main/java/com/twtw/backend/domain/place/mapper/PlaceMapper.java
@@ -4,11 +4,14 @@ import com.twtw.backend.domain.place.entity.Place;
 import com.twtw.backend.domain.plan.dto.client.PlaceDetails;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface PlaceMapper {
     Place toEntity(PlaceDetails detail);
 
+    @Mapping(target = "longitude", source = "coordinate.longitude")
+    @Mapping(target = "latitude", source = "coordinate.latitude")
     PlaceDetails toPlaceResponse(Place place);
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
@@ -41,12 +41,6 @@ public class PlanController {
         return ResponseEntity.ok(planService.savePlan(request));
     }
 
-    @PostMapping("update")
-    public ResponseEntity<Void> updatePlan(@RequestBody UpdatePlanRequest updatePlanRequest) {
-        planService.updatePlan(updatePlanRequest);
-        return ResponseEntity.noContent().build();
-    }
-
     @GetMapping("/{id}")
     public ResponseEntity<PlanInfoResponse> getPlanById(@PathVariable UUID id) {
         return ResponseEntity.ok(planService.getPlanById(id));
@@ -72,5 +66,11 @@ public class PlanController {
     @GetMapping
     public ResponseEntity<List<PlanInfoResponse>> getPlans() {
         return ResponseEntity.ok(planService.getPlans());
+    }
+
+    @PostMapping("update")
+    public ResponseEntity<Void> updatePlan(@RequestBody final UpdatePlanRequest updatePlanRequest) {
+        planService.updatePlan(updatePlanRequest);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
@@ -3,6 +3,7 @@ package com.twtw.backend.domain.plan.controller;
 import com.twtw.backend.domain.plan.dto.client.SearchDestinationRequest;
 import com.twtw.backend.domain.plan.dto.request.PlanMemberRequest;
 import com.twtw.backend.domain.plan.dto.request.SavePlanRequest;
+import com.twtw.backend.domain.plan.dto.request.UpdatePlanRequest;
 import com.twtw.backend.domain.plan.dto.response.PlanDestinationResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanInfoResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanResponse;
@@ -38,6 +39,12 @@ public class PlanController {
     @PostMapping
     public ResponseEntity<PlanResponse> savePlan(@RequestBody SavePlanRequest request) {
         return ResponseEntity.ok(planService.savePlan(request));
+    }
+
+    @PostMapping("update")
+    public ResponseEntity<Void> updatePlan(@RequestBody UpdatePlanRequest updatePlanRequest) {
+        planService.updatePlan(updatePlanRequest);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/request/UpdatePlanRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/request/UpdatePlanRequest.java
@@ -1,0 +1,20 @@
+package com.twtw.backend.domain.plan.dto.request;
+
+import com.twtw.backend.domain.place.entity.CategoryGroupCode;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePlanRequest {
+    private UUID planId;
+    private String placeName;
+    private String placeUrl;
+    private CategoryGroupCode categoryGroupCode;
+    private String roadAddressName;
+    private Double longitude;
+    private Double latitude;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/request/UpdatePlanRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/request/UpdatePlanRequest.java
@@ -1,10 +1,12 @@
 package com.twtw.backend.domain.plan.dto.request;
 
 import com.twtw.backend.domain.place.entity.CategoryGroupCode;
-import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
@@ -4,6 +4,7 @@ import com.twtw.backend.domain.group.entity.Group;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.place.entity.CategoryGroupCode;
 import com.twtw.backend.domain.place.entity.Place;
+import com.twtw.backend.domain.plan.exception.PlanMakerNotExistsException;
 import com.twtw.backend.global.audit.AuditListener;
 import com.twtw.backend.global.audit.Auditable;
 import com.twtw.backend.global.audit.BaseTime;
@@ -107,5 +108,14 @@ public class Plan implements Auditable {
     public void updateMemberLocation(
             final Member member, final Double longitude, final Double latitude) {
         this.group.updateMemberLocation(member, longitude, latitude);
+    }
+
+    public UUID getPlanMakerId() {
+        return this.planMembers.stream()
+                .filter(PlanMember::getIsPlanMaker)
+                .findFirst()
+                .orElseThrow(PlanMakerNotExistsException::new)
+                .getMember()
+                .getId();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
@@ -7,6 +7,7 @@ import com.twtw.backend.domain.place.entity.Place;
 import com.twtw.backend.global.audit.AuditListener;
 import com.twtw.backend.global.audit.Auditable;
 import com.twtw.backend.global.audit.BaseTime;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -19,14 +20,17 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import org.hibernate.annotations.Where;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 
 @Getter
 @Entity
@@ -96,10 +100,12 @@ public class Plan implements Auditable {
             final String roadAddressName,
             final Double longitude,
             final Double latitude) {
-        this.place.update(placeName, placeUrl, categoryGroupCode, roadAddressName, longitude, latitude);
+        this.place.update(
+                placeName, placeUrl, categoryGroupCode, roadAddressName, longitude, latitude);
     }
 
-    public void updateMemberLocation(final Member member, final Double longitude, final Double latitude) {
+    public void updateMemberLocation(
+            final Member member, final Double longitude, final Double latitude) {
         this.group.updateMemberLocation(member, longitude, latitude);
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanMember.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanMember.java
@@ -61,4 +61,8 @@ public class PlanMember implements Auditable {
     public boolean hasSameMember(final Member member) {
         return this.member.equals(member);
     }
+
+    public void updateToPlanMaker() {
+        this.isPlanMaker = true;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
@@ -14,6 +14,7 @@ import com.twtw.backend.domain.plan.dto.client.SearchDestinationRequest;
 import com.twtw.backend.domain.plan.dto.client.SearchDestinationResponse;
 import com.twtw.backend.domain.plan.dto.request.PlanMemberRequest;
 import com.twtw.backend.domain.plan.dto.request.SavePlanRequest;
+import com.twtw.backend.domain.plan.dto.request.UpdatePlanRequest;
 import com.twtw.backend.domain.plan.dto.response.PlanDestinationResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanInfoResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanResponse;
@@ -114,7 +115,7 @@ public class PlanService {
         return memberService.getMemberResponses(plan);
     }
 
-    private Plan getPlanEntity(UUID id) {
+    public Plan getPlanEntity(UUID id) {
         return planRepository.findById(id).orElseThrow(EntityNotFoundException::new);
     }
 
@@ -122,5 +123,17 @@ public class PlanService {
         final Member member = authService.getMemberByJwt();
         final List<Plan> plans = planRepository.findAllByMember(member);
         return planMapper.toPlanInfoResponses(plans);
+    }
+
+    public void updatePlan(final UpdatePlanRequest updatePlanRequest) {
+        final Plan plan = getPlanEntity(updatePlanRequest.getPlanId());
+
+        plan.updatePlace(
+                updatePlanRequest.getPlaceName(),
+                updatePlanRequest.getPlaceUrl(),
+                updatePlanRequest.getCategoryGroupCode(),
+                updatePlanRequest.getRoadAddressName(),
+                updatePlanRequest.getLongitude(),
+                updatePlanRequest.getLatitude());
     }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
@@ -2,9 +2,9 @@ package com.twtw.backend.domain.group.controller;
 
 import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
 import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -15,22 +15,22 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
 import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
 import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
+import com.twtw.backend.domain.group.dto.request.OutGroupRequest;
+import com.twtw.backend.domain.group.dto.request.UpdateLocationRequest;
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
 import com.twtw.backend.support.docs.RestDocsTest;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 @DisplayName("GroupController의")
 @WebMvcTest(GroupController.class)
@@ -271,5 +271,49 @@ class GroupControllerTest extends RestDocsTest {
 
         perform.andDo(print())
                 .andDo(document("get myGroups", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("자신의 위치가 정상적으로 수정되는가")
+    void updateLocation() throws Exception {
+        // given
+        willDoNothing().given(groupService).updateLocation(any());
+
+        // when`
+        final ResultActions perform =
+                mockMvc.perform(
+                        post("/group/location")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toRequestBody(new UpdateLocationRequest(UUID.randomUUID(), 0.0, 0.0)))
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+        // then
+        perform.andExpect(status().isNoContent());
+
+        perform.andDo(print())
+                .andDo(document("post update group member location", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("그룹 탈퇴가 수행되는가")
+    void outGroup() throws Exception {
+        // given
+        willDoNothing().given(groupService).outGroup(any());
+
+        // when
+        final ResultActions perform =
+                mockMvc.perform(
+                        post("/group/out")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toRequestBody(new OutGroupRequest(UUID.randomUUID())))
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+        // then
+        perform.andExpect(status().isNoContent());
+
+        perform.andDo(print())
+                .andDo(document("post out group", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
@@ -2,6 +2,7 @@ package com.twtw.backend.domain.group.controller;
 
 import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
 import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -22,15 +23,17 @@ import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
 import com.twtw.backend.support.docs.RestDocsTest;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @DisplayName("GroupController의")
 @WebMvcTest(GroupController.class)
@@ -284,7 +287,10 @@ class GroupControllerTest extends RestDocsTest {
                 mockMvc.perform(
                         post("/group/location")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(toRequestBody(new UpdateLocationRequest(UUID.randomUUID(), 0.0, 0.0)))
+                                .content(
+                                        toRequestBody(
+                                                new UpdateLocationRequest(
+                                                        UUID.randomUUID(), 0.0, 0.0)))
                                 .header(
                                         "Authorization",
                                         "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
@@ -292,7 +298,11 @@ class GroupControllerTest extends RestDocsTest {
         perform.andExpect(status().isNoContent());
 
         perform.andDo(print())
-                .andDo(document("post update group member location", getDocumentRequest(), getDocumentResponse()));
+                .andDo(
+                        document(
+                                "post update group member location",
+                                getDocumentRequest(),
+                                getDocumentResponse()));
     }
 
     @Test

--- a/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
@@ -2,9 +2,9 @@ package com.twtw.backend.domain.plan.controller;
 
 import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
 import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -15,24 +15,24 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.member.dto.response.MemberResponse;
+import com.twtw.backend.domain.place.entity.CategoryGroupCode;
 import com.twtw.backend.domain.plan.dto.client.PlaceDetails;
 import com.twtw.backend.domain.plan.dto.request.PlanMemberRequest;
 import com.twtw.backend.domain.plan.dto.request.SavePlanRequest;
+import com.twtw.backend.domain.plan.dto.request.UpdatePlanRequest;
 import com.twtw.backend.domain.plan.dto.response.PlanDestinationResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanInfoResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanResponse;
 import com.twtw.backend.domain.plan.service.PlanService;
 import com.twtw.backend.support.docs.RestDocsTest;
-
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.util.List;
-import java.util.UUID;
 
 @DisplayName("PlanController의")
 @WebMvcTest(PlanController.class)
@@ -253,5 +253,28 @@ class PlanControllerTest extends RestDocsTest {
         // docs
         perform.andDo(print())
                 .andDo(document("get all plans", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("계획 장소 업데이트 API가 수행되는가")
+    void updatePlan() throws Exception {
+        // given
+        willDoNothing().given(planService).updatePlan(any());
+
+        // when
+        final ResultActions perform =
+                mockMvc.perform(
+                        post("/plans/update")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toRequestBody(new UpdatePlanRequest(UUID.randomUUID(), "별다방", "http://place.map.kakao.com/1562566188", CategoryGroupCode.CE7, "경기 안성시 죽산면 죽주로 287-1", 127.426865189637, 37.0764635355795)))
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+        // then
+        perform.andExpect(status().isNoContent());
+
+        // docs
+        perform.andDo(print())
+                .andDo(document("post update plan", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
@@ -17,9 +17,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.member.dto.response.MemberResponse;
 import com.twtw.backend.domain.place.entity.CategoryGroupCode;
-import com.twtw.backend.domain.plan.dto.request.UpdatePlanRequest;
 import com.twtw.backend.domain.plan.dto.request.PlanMemberRequest;
 import com.twtw.backend.domain.plan.dto.request.SavePlanRequest;
+import com.twtw.backend.domain.plan.dto.request.UpdatePlanRequest;
 import com.twtw.backend.domain.plan.dto.response.PlaceDetails;
 import com.twtw.backend.domain.plan.dto.response.PlanDestinationResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanInfoResponse;

--- a/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
@@ -2,6 +2,7 @@ package com.twtw.backend.domain.plan.controller;
 
 import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
 import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -25,14 +26,16 @@ import com.twtw.backend.domain.plan.dto.response.PlanInfoResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanResponse;
 import com.twtw.backend.domain.plan.service.PlanService;
 import com.twtw.backend.support.docs.RestDocsTest;
-import java.util.List;
-import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.UUID;
 
 @DisplayName("PlanController의")
 @WebMvcTest(PlanController.class)
@@ -266,7 +269,16 @@ class PlanControllerTest extends RestDocsTest {
                 mockMvc.perform(
                         post("/plans/update")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(toRequestBody(new UpdatePlanRequest(UUID.randomUUID(), "별다방", "http://place.map.kakao.com/1562566188", CategoryGroupCode.CE7, "경기 안성시 죽산면 죽주로 287-1", 127.426865189637, 37.0764635355795)))
+                                .content(
+                                        toRequestBody(
+                                                new UpdatePlanRequest(
+                                                        UUID.randomUUID(),
+                                                        "별다방",
+                                                        "http://place.map.kakao.com/1562566188",
+                                                        CategoryGroupCode.CE7,
+                                                        "경기 안성시 죽산면 죽주로 287-1",
+                                                        127.426865189637,
+                                                        37.0764635355795)))
                                 .header(
                                         "Authorization",
                                         "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 목적지 수정 api
- 계획에 포함된 멤버들 위치 변경 api
- 중간지점 알려주는 api
- 그룹 나가기 api
- 그룹, 계획 나갈 때 리더 넘겨주도록 수정

## 특이사항
- 좌표 저장 및 거리 계산에 redis 사용 -> GeoService 참고
- 소켓에서 헤더로 jwt 받도록 수정
- 프로필 이미지 저장 api 구현 예정

## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
