### PR TITLE
[FEAT] GroupInfoResponse 에 해당 그룹의 소속 그룹원 정보 추가

### DIFF
--- a/backend/src/main/java/com/twtw/backend/domain/group/dto/response/GroupInfoResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/dto/response/GroupInfoResponse.java
@@ -1,6 +1,7 @@
 package com.twtw.backend.domain.group.dto.response;
 
 import com.twtw.backend.domain.member.dto.response.MemberResponse;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/src/main/java/com/twtw/backend/domain/group/dto/response/GroupInfoResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/dto/response/GroupInfoResponse.java
@@ -1,9 +1,11 @@
 package com.twtw.backend.domain.group.dto.response;
 
+import com.twtw.backend.domain.member.dto.response.MemberResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -14,4 +16,5 @@ public class GroupInfoResponse {
     private UUID leaderId;
     private String name;
     private String groupImage;
+    private List<MemberResponse> groupMembers;
 }

--- a/backend/src/main/java/com/twtw/backend/domain/group/mapper/GroupMapper.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/mapper/GroupMapper.java
@@ -5,6 +5,7 @@ import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.entity.Group;
 import com.twtw.backend.domain.group.entity.GroupMember;
+import com.twtw.backend.domain.member.dto.response.MemberResponse;
 import com.twtw.backend.domain.member.entity.Member;
 
 import org.mapstruct.IterableMapping;
@@ -21,7 +22,17 @@ public interface GroupMapper {
     @Mapping(target = "groupImage", source = "groupDto.groupImage")
     Group toGroupEntity(MakeGroupRequest groupDto, Member leader);
 
+    @Named("groupMemberToMemberResponse")
+    @Mapping(target = "id",source = "groupMember.member.id")
+    @Mapping(target = "nickname",source = "groupMember.member.nickname")
+    MemberResponse toGroupMemberResponse(GroupMember groupMember);
+
+    @Named("groupMemberToMemberResponseList")
+    @IterableMapping(qualifiedByName = "groupMemberToMemberResponse")
+    List<MemberResponse> toGroupMemberResponseList(List<GroupMember> groupMemberList);
+
     @Mapping(target = "groupId", source = "id")
+    @Mapping(target = "groupMembers", qualifiedByName = "groupMemberToMemberResponseList")
     GroupInfoResponse toGroupInfo(Group group);
 
     @Mapping(target = "groupId", source = "group.id")

--- a/backend/src/main/java/com/twtw/backend/domain/group/mapper/GroupMapper.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/mapper/GroupMapper.java
@@ -23,8 +23,8 @@ public interface GroupMapper {
     Group toGroupEntity(MakeGroupRequest groupDto, Member leader);
 
     @Named("groupMemberToMemberResponse")
-    @Mapping(target = "id",source = "groupMember.member.id")
-    @Mapping(target = "nickname",source = "groupMember.member.nickname")
+    @Mapping(target = "id", source = "groupMember.member.id")
+    @Mapping(target = "nickname", source = "groupMember.member.nickname")
     MemberResponse toGroupMemberResponse(GroupMember groupMember);
 
     @Named("groupMemberToMemberResponseList")

--- a/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
@@ -22,6 +22,7 @@ import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
+import com.twtw.backend.domain.member.dto.response.MemberResponse;
 import com.twtw.backend.support.docs.RestDocsTest;
 
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +50,12 @@ class GroupControllerTest extends RestDocsTest {
                         UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
                         UUID.randomUUID(),
                         "HDJ",
-                        "GROUP-IMAGE");
+                        "GROUP-IMAGE",
+                        List.of(
+                                new MemberResponse(UUID.randomUUID(),"DEAN"),
+                                new MemberResponse(UUID.randomUUID(),"ZION-T")
+                        )
+                        );
         given(groupService.getGroupById(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")))
                 .willReturn(expected);
 
@@ -75,7 +81,11 @@ class GroupControllerTest extends RestDocsTest {
                         UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
                         UUID.randomUUID(),
                         "HDJ",
-                        "GROUP-IMAGE");
+                        "GROUP-IMAGE",
+                        List.of(
+                                new MemberResponse(UUID.randomUUID(),"DEAN"),
+                                new MemberResponse(UUID.randomUUID(),"ZION-T")
+                        ));
         given(groupService.makeGroup(any())).willReturn(expected);
 
         final ResultActions perform =
@@ -128,7 +138,10 @@ class GroupControllerTest extends RestDocsTest {
         // given
         final GroupInfoResponse expected =
                 new GroupInfoResponse(
-                        UUID.randomUUID(), UUID.randomUUID(), "홍담진", "http://someUrlToS3");
+                        UUID.randomUUID(), UUID.randomUUID(), "홍담진", "http://someUrlToS3",List.of(
+                        new MemberResponse(UUID.randomUUID(),"DEAN"),
+                        new MemberResponse(UUID.randomUUID(),"ZION-T")
+                ));
         given(groupService.inviteGroup(any())).willReturn(expected);
 
         // when
@@ -252,9 +265,15 @@ class GroupControllerTest extends RestDocsTest {
         List<GroupInfoResponse> responseList = new ArrayList<>();
 
         GroupInfoResponse response1 =
-                new GroupInfoResponse(UUID.randomUUID(), leaderId, "BLACK_PINK", "I_LOVE_YOU_LOSE");
+                new GroupInfoResponse(UUID.randomUUID(), leaderId, "BLACK_PINK", "I_LOVE_YOU_LOSE",List.of(
+                        new MemberResponse(UUID.randomUUID(),"LISA"),
+                        new MemberResponse(UUID.randomUUID(),"제니")
+                ));
         GroupInfoResponse response2 =
-                new GroupInfoResponse(UUID.randomUUID(), leaderId, "LE_SSERAFIM", "I_LOVE_YOU_채원");
+                new GroupInfoResponse(UUID.randomUUID(), leaderId, "LE_SSERAFIM", "I_LOVE_YOU_채원",List.of(
+                        new MemberResponse(UUID.randomUUID(),"카즈하"),
+                        new MemberResponse(UUID.randomUUID(),"사쿠라")
+                ));
 
         responseList.add(response1);
         responseList.add(response2);

--- a/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
@@ -52,10 +52,8 @@ class GroupControllerTest extends RestDocsTest {
                         "HDJ",
                         "GROUP-IMAGE",
                         List.of(
-                                new MemberResponse(UUID.randomUUID(),"DEAN"),
-                                new MemberResponse(UUID.randomUUID(),"ZION-T")
-                        )
-                        );
+                                new MemberResponse(UUID.randomUUID(), "DEAN"),
+                                new MemberResponse(UUID.randomUUID(), "ZION-T")));
         given(groupService.getGroupById(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")))
                 .willReturn(expected);
 
@@ -83,9 +81,8 @@ class GroupControllerTest extends RestDocsTest {
                         "HDJ",
                         "GROUP-IMAGE",
                         List.of(
-                                new MemberResponse(UUID.randomUUID(),"DEAN"),
-                                new MemberResponse(UUID.randomUUID(),"ZION-T")
-                        ));
+                                new MemberResponse(UUID.randomUUID(), "DEAN"),
+                                new MemberResponse(UUID.randomUUID(), "ZION-T")));
         given(groupService.makeGroup(any())).willReturn(expected);
 
         final ResultActions perform =
@@ -138,10 +135,13 @@ class GroupControllerTest extends RestDocsTest {
         // given
         final GroupInfoResponse expected =
                 new GroupInfoResponse(
-                        UUID.randomUUID(), UUID.randomUUID(), "홍담진", "http://someUrlToS3",List.of(
-                        new MemberResponse(UUID.randomUUID(),"DEAN"),
-                        new MemberResponse(UUID.randomUUID(),"ZION-T")
-                ));
+                        UUID.randomUUID(),
+                        UUID.randomUUID(),
+                        "홍담진",
+                        "http://someUrlToS3",
+                        List.of(
+                                new MemberResponse(UUID.randomUUID(), "DEAN"),
+                                new MemberResponse(UUID.randomUUID(), "ZION-T")));
         given(groupService.inviteGroup(any())).willReturn(expected);
 
         // when
@@ -265,15 +265,23 @@ class GroupControllerTest extends RestDocsTest {
         List<GroupInfoResponse> responseList = new ArrayList<>();
 
         GroupInfoResponse response1 =
-                new GroupInfoResponse(UUID.randomUUID(), leaderId, "BLACK_PINK", "I_LOVE_YOU_LOSE",List.of(
-                        new MemberResponse(UUID.randomUUID(),"LISA"),
-                        new MemberResponse(UUID.randomUUID(),"제니")
-                ));
+                new GroupInfoResponse(
+                        UUID.randomUUID(),
+                        leaderId,
+                        "BLACK_PINK",
+                        "I_LOVE_YOU_LOSE",
+                        List.of(
+                                new MemberResponse(UUID.randomUUID(), "LISA"),
+                                new MemberResponse(UUID.randomUUID(), "제니")));
         GroupInfoResponse response2 =
-                new GroupInfoResponse(UUID.randomUUID(), leaderId, "LE_SSERAFIM", "I_LOVE_YOU_채원",List.of(
-                        new MemberResponse(UUID.randomUUID(),"카즈하"),
-                        new MemberResponse(UUID.randomUUID(),"사쿠라")
-                ));
+                new GroupInfoResponse(
+                        UUID.randomUUID(),
+                        leaderId,
+                        "LE_SSERAFIM",
+                        "I_LOVE_YOU_채원",
+                        List.of(
+                                new MemberResponse(UUID.randomUUID(), "카즈하"),
+                                new MemberResponse(UUID.randomUUID(), "사쿠라")));
 
         responseList.add(response1);
         responseList.add(response2);

--- a/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
@@ -152,7 +152,7 @@ class GroupServiceTest extends LoginTest {
 
     @Test
     @DisplayName("GroupId를 통한 Group 조회가 성공적인가")
-    void getGroupById(){
+    void getGroupById() {
         // given
         Member leader = memberRepository.save(MemberEntityFixture.FIRST_MEMBER.toEntity());
 

--- a/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
@@ -149,4 +149,25 @@ class GroupServiceTest extends LoginTest {
         // then
         assertThat(responses).hasSize(2);
     }
+
+    @Test
+    @DisplayName("GroupId를 통한 Group 조회가 성공적인가")
+    void getGroupById(){
+        // given
+        Member leader = memberRepository.save(MemberEntityFixture.FIRST_MEMBER.toEntity());
+
+        Group group1 = new Group("BABY_MONSTER", "YG_OFFICIAL_IMAGE", leader);
+
+        GroupMember groupMember1 = new GroupMember(group1, loginUser);
+
+        group1.getGroupMembers().add(groupMember1);
+
+        Group saveGroup1 = groupRepository.save(group1);
+        // when
+
+        GroupInfoResponse response = groupService.getGroupById(saveGroup1.getId());
+
+        // then
+        assertThat(response.getGroupMembers()).hasSize(2);
+    }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/path/controller/PathControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/path/controller/PathControllerTest.java
@@ -85,23 +85,25 @@ class PathControllerTest extends RestDocsTest {
     @DisplayName("보행자 경로 검색 API가 수행되는가")
     void searchPedPath() throws Exception {
         // given
-        final SearchPedPathResponse expected = new SearchPedPathResponse("FeatureCollection", List.of(
-                new Feature(
-                        "Feature",
-                        new Geometry(
-                               "Point",
-                                new Double[][]{{126.92364104902308,37.556759264185274}}
-                        )
-                ),
-
-                new Feature(
-                        "Feature",
-                        new Geometry(
-                                "LineString",
-                                new Double[][]{{126.92364104902308,37.556759264185274},{126.92359383142113,37.55672315696065}}
-                        )
-                )
-        ));
+        final SearchPedPathResponse expected =
+                new SearchPedPathResponse(
+                        "FeatureCollection",
+                        List.of(
+                                new Feature(
+                                        "Feature",
+                                        new Geometry(
+                                                "Point",
+                                                new Double[][] {
+                                                    {126.92364104902308, 37.556759264185274}
+                                                })),
+                                new Feature(
+                                        "Feature",
+                                        new Geometry(
+                                                "LineString",
+                                                new Double[][] {
+                                                    {126.92364104902308, 37.556759264185274},
+                                                    {126.92359383142113, 37.55672315696065}
+                                                }))));
 
         given(pathService.searchPedPath(any())).willReturn(expected);
 
@@ -112,11 +114,12 @@ class PathControllerTest extends RestDocsTest {
                                 .content(
                                         toRequestBody(
                                                 new SearchPedPathRequest(
-                                                        37.636040,126.827507,
-                                                        37.644998,126.832659,
+                                                        37.636040,
+                                                        126.827507,
+                                                        37.644998,
+                                                        126.832659,
                                                         "startPoint",
-                                                        "endPoint"
-                                                )))
+                                                        "endPoint")))
                                 .contentType(MediaType.APPLICATION_JSON));
 
         // then

--- a/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
@@ -141,7 +141,10 @@ class PlanControllerTest extends RestDocsTest {
                                 127.420430538256,
                                 37.0766874564297),
                         new GroupInfoResponse(
-                                UUID.randomUUID(), UUID.randomUUID(), "홍담진", "http://someUrlToS3"),
+                                UUID.randomUUID(), UUID.randomUUID(), "홍담진", "http://someUrlToS3",List.of(
+                                new MemberResponse(UUID.randomUUID(),"카즈하"),
+                                new MemberResponse(UUID.randomUUID(),"사쿠라")
+                        )),
                         List.of(new MemberResponse(UUID.randomUUID(), "진호정")));
         given(planService.getPlanById(any())).willReturn(expected);
 
@@ -263,7 +266,10 @@ class PlanControllerTest extends RestDocsTest {
                                         UUID.randomUUID(),
                                         UUID.randomUUID(),
                                         "홍담진",
-                                        "http://someUrlToS3"),
+                                        "http://someUrlToS3",List.of(
+                                        new MemberResponse(UUID.randomUUID(),"카즈하"),
+                                        new MemberResponse(UUID.randomUUID(),"사쿠라")
+                                )),
                                 List.of(new MemberResponse(UUID.randomUUID(), "진호정"))),
                         new PlanInfoResponse(
                                 UUID.randomUUID(),
@@ -279,7 +285,10 @@ class PlanControllerTest extends RestDocsTest {
                                         UUID.randomUUID(),
                                         UUID.randomUUID(),
                                         "HongDamJin",
-                                        "http://someUrlToS3"),
+                                        "http://someUrlToS3",List.of(
+                                        new MemberResponse(UUID.randomUUID(),"카즈하"),
+                                        new MemberResponse(UUID.randomUUID(),"사쿠라")
+                                )),
                                 List.of(new MemberResponse(UUID.randomUUID(), "JinHoJeong"))));
 
         given(planService.getPlans()).willReturn(expected);

--- a/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
@@ -141,10 +141,13 @@ class PlanControllerTest extends RestDocsTest {
                                 127.420430538256,
                                 37.0766874564297),
                         new GroupInfoResponse(
-                                UUID.randomUUID(), UUID.randomUUID(), "홍담진", "http://someUrlToS3",List.of(
-                                new MemberResponse(UUID.randomUUID(),"카즈하"),
-                                new MemberResponse(UUID.randomUUID(),"사쿠라")
-                        )),
+                                UUID.randomUUID(),
+                                UUID.randomUUID(),
+                                "홍담진",
+                                "http://someUrlToS3",
+                                List.of(
+                                        new MemberResponse(UUID.randomUUID(), "카즈하"),
+                                        new MemberResponse(UUID.randomUUID(), "사쿠라"))),
                         List.of(new MemberResponse(UUID.randomUUID(), "진호정")));
         given(planService.getPlanById(any())).willReturn(expected);
 
@@ -266,10 +269,10 @@ class PlanControllerTest extends RestDocsTest {
                                         UUID.randomUUID(),
                                         UUID.randomUUID(),
                                         "홍담진",
-                                        "http://someUrlToS3",List.of(
-                                        new MemberResponse(UUID.randomUUID(),"카즈하"),
-                                        new MemberResponse(UUID.randomUUID(),"사쿠라")
-                                )),
+                                        "http://someUrlToS3",
+                                        List.of(
+                                                new MemberResponse(UUID.randomUUID(), "카즈하"),
+                                                new MemberResponse(UUID.randomUUID(), "사쿠라"))),
                                 List.of(new MemberResponse(UUID.randomUUID(), "진호정"))),
                         new PlanInfoResponse(
                                 UUID.randomUUID(),
@@ -285,10 +288,10 @@ class PlanControllerTest extends RestDocsTest {
                                         UUID.randomUUID(),
                                         UUID.randomUUID(),
                                         "HongDamJin",
-                                        "http://someUrlToS3",List.of(
-                                        new MemberResponse(UUID.randomUUID(),"카즈하"),
-                                        new MemberResponse(UUID.randomUUID(),"사쿠라")
-                                )),
+                                        "http://someUrlToS3",
+                                        List.of(
+                                                new MemberResponse(UUID.randomUUID(), "카즈하"),
+                                                new MemberResponse(UUID.randomUUID(), "사쿠라"))),
                                 List.of(new MemberResponse(UUID.randomUUID(), "JinHoJeong"))));
 
         given(planService.getPlans()).willReturn(expected);


### PR DESCRIPTION
## 추가/수정한 기능 설명
1. GroupMapper에 변환 방법 추가
2. GroupInfoResponse에 List<MemberResponse> 추가
## 특이사항


## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
