### PR TITLE
[FEAT] 그룹, 계획 초대 중복 제거 및 초대 승락/삭제 api 추가

### DIFF
--- a/backend/src/docs/group.adoc
+++ b/backend/src/docs/group.adoc
@@ -17,6 +17,9 @@ operation::post join group[snippets='http-request,http-response']
 === 그룹 초대
 operation::post invite group[snippets='http-request,http-response']
 
+=== 그룹 초대 삭제
+operation::delete group invite[snippets='http-request,http-response']
+
 === 위치 공유 ON
 operation::post share location[snippets='http-request,http-response']
 

--- a/backend/src/docs/plan.adoc
+++ b/backend/src/docs/plan.adoc
@@ -17,8 +17,14 @@ operation::get plan[snippets='http-request,http-response']
 === 계획 삭제
 operation::delete plan[snippets='http-request,http-response']
 
+=== 계획 초대
+operation::post invite plan[snippets='http-request,http-response']
+
 === 계획 참여
 operation::post join plan[snippets='http-request,http-response']
+
+=== 계획 초대 삭제
+operation::delete plan invite[snippets='http-request,http-response']
 
 === 계획 탈퇴
 operation::post out plan[snippets='http-request,http-response']

--- a/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
@@ -1,22 +1,13 @@
 package com.twtw.backend.domain.group.controller;
 
-import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
-import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
-import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
-import com.twtw.backend.domain.group.dto.request.OutGroupRequest;
-import com.twtw.backend.domain.group.dto.request.UpdateLocationRequest;
+import com.twtw.backend.domain.group.dto.request.DeleteGroupInviteRequest;
+import com.twtw.backend.domain.group.dto.request.*;
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
-
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -51,6 +42,12 @@ public class GroupController {
     public ResponseEntity<GroupInfoResponse> inviteGroup(
             @RequestBody InviteGroupRequest inviteGroupRequest) {
         return ResponseEntity.ok(groupService.inviteGroup(inviteGroupRequest));
+    }
+
+    @DeleteMapping("/invite")
+    public ResponseEntity<Void> deleteInvite(@RequestBody DeleteGroupInviteRequest deleteGroupInviteRequest) {
+        groupService.deleteInvite(deleteGroupInviteRequest);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/share/{id}")

--- a/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/controller/GroupController.java
@@ -1,11 +1,12 @@
 package com.twtw.backend.domain.group.controller;
 
-import com.twtw.backend.domain.group.dto.request.DeleteGroupInviteRequest;
 import com.twtw.backend.domain.group.dto.request.*;
+import com.twtw.backend.domain.group.dto.request.DeleteGroupInviteRequest;
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,7 +46,8 @@ public class GroupController {
     }
 
     @DeleteMapping("/invite")
-    public ResponseEntity<Void> deleteInvite(@RequestBody DeleteGroupInviteRequest deleteGroupInviteRequest) {
+    public ResponseEntity<Void> deleteInvite(
+            @RequestBody DeleteGroupInviteRequest deleteGroupInviteRequest) {
         groupService.deleteInvite(deleteGroupInviteRequest);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/twtw/backend/domain/group/dto/request/DeleteGroupInviteRequest.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/dto/request/DeleteGroupInviteRequest.java
@@ -1,0 +1,14 @@
+package com.twtw.backend.domain.group.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteGroupInviteRequest {
+    private UUID groupId;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/group/entity/Group.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/entity/Group.java
@@ -85,7 +85,9 @@ public class Group implements Auditable {
     }
 
     private boolean hasSameMember(final GroupMember groupMember) {
-        return this.groupMembers.stream().map(GroupMember::getMember).anyMatch(groupMember::isSameMember);
+        return this.groupMembers.stream()
+                .map(GroupMember::getMember)
+                .anyMatch(groupMember::isSameMember);
     }
 
     public void updateMemberLocation(

--- a/backend/src/main/java/com/twtw/backend/domain/group/entity/Group.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/entity/Group.java
@@ -73,8 +73,19 @@ public class Group implements Auditable {
         friends.forEach(friend -> addGroupMember(new GroupMember(this, friend)));
     }
 
-    private boolean addGroupMember(final GroupMember groupMember) {
-        return this.groupMembers.add(groupMember);
+    public List<GroupMember> getGroupMembers() {
+        return this.groupMembers.stream().filter(GroupMember::isAccepted).toList();
+    }
+
+    private void addGroupMember(final GroupMember groupMember) {
+        if (hasSameMember(groupMember)) {
+            return;
+        }
+        this.groupMembers.add(groupMember);
+    }
+
+    private boolean hasSameMember(final GroupMember groupMember) {
+        return this.groupMembers.stream().map(GroupMember::getMember).anyMatch(groupMember::isSameMember);
     }
 
     public void updateMemberLocation(
@@ -99,5 +110,9 @@ public class Group implements Auditable {
 
     private boolean hasNoLeader() {
         return this.groupMembers.stream().noneMatch(GroupMember::isLeader);
+    }
+
+    public void deleteInvite(final Member member) {
+        this.groupMembers.removeIf(groupMember -> groupMember.isSameMember(member));
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/group/entity/GroupMember.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/entity/GroupMember.java
@@ -102,4 +102,8 @@ public class GroupMember implements Auditable {
     public boolean isLeader() {
         return this.group.getLeaderId().equals(this.member.getId());
     }
+
+    public boolean isAccepted() {
+        return this.groupInviteCode == GroupInviteCode.ACCEPTED;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/group/service/GroupService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/group/service/GroupService.java
@@ -1,10 +1,6 @@
 package com.twtw.backend.domain.group.service;
 
-import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
-import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
-import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
-import com.twtw.backend.domain.group.dto.request.OutGroupRequest;
-import com.twtw.backend.domain.group.dto.request.UpdateLocationRequest;
+import com.twtw.backend.domain.group.dto.request.*;
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
@@ -147,5 +143,12 @@ public class GroupService {
         final Member member = authService.getMemberByJwt();
         final Group group = getGroupEntity(outGroupRequest.getGroupId());
         group.outGroup(member);
+    }
+
+    @Transactional
+    public void deleteInvite(final DeleteGroupInviteRequest deleteGroupInviteRequest) {
+        final Member member = authService.getMemberByJwt();
+        final Group group = getGroupEntity(deleteGroupInviteRequest.getGroupId());
+        group.deleteInvite(member);
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/controller/PlanController.java
@@ -53,9 +53,21 @@ public class PlanController {
         return ResponseEntity.noContent().build();
     }
 
+    @PostMapping("/invite")
+    public ResponseEntity<PlanResponse> invitePlan(@RequestBody PlanMemberRequest request) {
+        return ResponseEntity.ok(planService.invitePlan(request));
+    }
+
+    @DeleteMapping("/invite")
+    public ResponseEntity<Void> deleteInvite(@RequestBody PlanMemberRequest request) {
+        planService.deleteInvite(request);
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/join")
-    public ResponseEntity<PlanResponse> joinPlan(@RequestBody PlanMemberRequest request) {
-        return ResponseEntity.ok(planService.joinPlan(request));
+    public ResponseEntity<Void> joinPlan(@RequestBody PlanMemberRequest request) {
+        planService.joinPlan(request);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/out")

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/Plan.java
@@ -8,11 +8,14 @@ import com.twtw.backend.domain.plan.exception.PlanMakerNotExistsException;
 import com.twtw.backend.global.audit.AuditListener;
 import com.twtw.backend.global.audit.Auditable;
 import com.twtw.backend.global.audit.BaseTime;
+
 import jakarta.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanInviteCode.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanInviteCode.java
@@ -1,0 +1,12 @@
+package com.twtw.backend.domain.plan.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PlanInviteCode {
+    REQUESTED("요청"),
+    ACCEPTED("승인"),
+    DENIED("거절");
+
+    private final String toKorean;
+}

--- a/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanMember.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/entity/PlanMember.java
@@ -5,15 +5,7 @@ import com.twtw.backend.global.audit.AuditListener;
 import com.twtw.backend.global.audit.Auditable;
 import com.twtw.backend.global.audit.BaseTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -44,6 +36,9 @@ public class PlanMember implements Auditable {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    @Enumerated(EnumType.STRING)
+    private PlanInviteCode planInviteCode;
+
     private Boolean isPlanMaker;
 
     @Setter
@@ -56,13 +51,22 @@ public class PlanMember implements Auditable {
         this.plan = plan;
         this.member = member;
         this.isPlanMaker = isPlanMaker;
+        this.planInviteCode = PlanInviteCode.REQUESTED;
     }
 
-    public boolean hasSameMember(final Member member) {
+    public boolean isSameMember(final Member member) {
         return this.member.equals(member);
     }
 
     public void updateToPlanMaker() {
         this.isPlanMaker = true;
+    }
+
+    public boolean isAccepted() {
+        return this.planInviteCode == PlanInviteCode.ACCEPTED;
+    }
+
+    public void acceptInvite() {
+        this.planInviteCode = PlanInviteCode.ACCEPTED;
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
@@ -84,7 +84,8 @@ public class PlanService {
         return planMapper.toPlanResponse(planRepository.save(plan));
     }
 
-    public PlanResponse joinPlan(PlanMemberRequest request) {
+    @Transactional
+    public PlanResponse invitePlan(PlanMemberRequest request) {
         Member member = authService.getMemberByJwt();
         Plan plan = getPlanEntity(request.getPlanId());
         plan.addMember(member);
@@ -148,5 +149,19 @@ public class PlanService {
     public void updatePlanDay(final UpdatePlanDayRequest request) {
         final Plan plan = getPlanEntity(request.getPlanId());
         plan.updatePlanDay(request.getChangeDay());
+    }
+
+    @Transactional
+    public void joinPlan(final PlanMemberRequest request) {
+        Member member = authService.getMemberByJwt();
+        Plan plan = getPlanEntity(request.getPlanId());
+        plan.acceptInvite(member);
+    }
+
+    @Transactional
+    public void deleteInvite(final PlanMemberRequest request) {
+        Member member = authService.getMemberByJwt();
+        Plan plan = getPlanEntity(request.getPlanId());
+        plan.deleteInvite(member);
     }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
@@ -1,5 +1,17 @@
 package com.twtw.backend.domain.group.controller;
 
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.twtw.backend.domain.group.dto.request.*;
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
@@ -7,6 +19,7 @@ import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
 import com.twtw.backend.domain.member.dto.response.MemberResponse;
 import com.twtw.backend.support.docs.RestDocsTest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -17,17 +30,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("GroupController의")
 @WebMvcTest(GroupController.class)
@@ -172,7 +174,9 @@ class GroupControllerTest extends RestDocsTest {
                 mockMvc.perform(
                         delete("/group/invite")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(toRequestBody(new DeleteGroupInviteRequest(UUID.randomUUID())))
+                                .content(
+                                        toRequestBody(
+                                                new DeleteGroupInviteRequest(UUID.randomUUID())))
                                 .header(
                                         "Authorization",
                                         "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
@@ -182,7 +186,11 @@ class GroupControllerTest extends RestDocsTest {
 
         // docs
         perform.andDo(print())
-                .andDo(document("delete group invite", getDocumentRequest(), getDocumentResponse()));
+                .andDo(
+                        document(
+                                "delete group invite",
+                                getDocumentRequest(),
+                                getDocumentResponse()));
     }
 
     @Test

--- a/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/controller/GroupControllerTest.java
@@ -1,30 +1,12 @@
 package com.twtw.backend.domain.group.controller;
 
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
-import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
-import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
-import com.twtw.backend.domain.group.dto.request.OutGroupRequest;
-import com.twtw.backend.domain.group.dto.request.UpdateLocationRequest;
+import com.twtw.backend.domain.group.dto.request.*;
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.group.dto.response.ShareInfoResponse;
 import com.twtw.backend.domain.group.dto.response.SimpleGroupInfoResponse;
 import com.twtw.backend.domain.group.service.GroupService;
 import com.twtw.backend.domain.member.dto.response.MemberResponse;
 import com.twtw.backend.support.docs.RestDocsTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -35,6 +17,17 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("GroupController의")
 @WebMvcTest(GroupController.class)
@@ -166,6 +159,30 @@ class GroupControllerTest extends RestDocsTest {
         // docs
         perform.andDo(print())
                 .andDo(document("post invite group", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("그룹 초대 삭제 API가 수행되는가")
+    void deleteInvite() throws Exception {
+        // given
+        willDoNothing().given(groupService).deleteInvite(any());
+
+        // when
+        final ResultActions perform =
+                mockMvc.perform(
+                        delete("/group/invite")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toRequestBody(new DeleteGroupInviteRequest(UUID.randomUUID())))
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+
+        // then
+        perform.andExpect(status().isNoContent());
+
+        // docs
+        perform.andDo(print())
+                .andDo(document("delete group invite", getDocumentRequest(), getDocumentResponse()));
     }
 
     @Test

--- a/backend/src/test/java/com/twtw/backend/domain/group/repository/GroupRepositoryTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/repository/GroupRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.twtw.backend.domain.group.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.twtw.backend.domain.group.entity.Group;
 import com.twtw.backend.domain.group.entity.GroupMember;
 import com.twtw.backend.domain.member.entity.Member;
@@ -10,14 +12,13 @@ import com.twtw.backend.fixture.group.GroupEntityFixture;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.fixture.place.PlaceEntityFixture;
 import com.twtw.backend.support.repository.RepositoryTest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("GroupRepository의")
 class GroupRepositoryTest extends RepositoryTest {

--- a/backend/src/test/java/com/twtw/backend/domain/group/repository/GroupRepositoryTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/repository/GroupRepositoryTest.java
@@ -1,7 +1,5 @@
 package com.twtw.backend.domain.group.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.twtw.backend.domain.group.entity.Group;
 import com.twtw.backend.domain.group.entity.GroupMember;
 import com.twtw.backend.domain.member.entity.Member;
@@ -12,13 +10,14 @@ import com.twtw.backend.fixture.group.GroupEntityFixture;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.fixture.place.PlaceEntityFixture;
 import com.twtw.backend.support.repository.RepositoryTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("GroupRepository의")
 class GroupRepositoryTest extends RepositoryTest {
@@ -49,7 +48,7 @@ class GroupRepositoryTest extends RepositoryTest {
         final Group saveGroup = groupRepository.save(group);
 
         // then
-        assertThat(saveGroup.getGroupMembers()).hasSize(2);
+        assertThat(saveGroup.getGroupMembers()).hasSize(1);
     }
 
     @Test

--- a/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
@@ -1,7 +1,5 @@
 package com.twtw.backend.domain.group.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
 import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
 import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
@@ -15,12 +13,13 @@ import com.twtw.backend.domain.group.repository.GroupRepository;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.service.LoginTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("GroupService의")
 class GroupServiceTest extends LoginTest {
@@ -158,9 +157,7 @@ class GroupServiceTest extends LoginTest {
 
         Group group1 = new Group("BABY_MONSTER", "YG_OFFICIAL_IMAGE", leader);
 
-        GroupMember groupMember1 = new GroupMember(group1, loginUser);
-
-        group1.getGroupMembers().add(groupMember1);
+        group1.inviteAll(List.of(loginUser));
 
         Group saveGroup1 = groupRepository.save(group1);
         // when
@@ -168,6 +165,6 @@ class GroupServiceTest extends LoginTest {
         GroupInfoResponse response = groupService.getGroupById(saveGroup1.getId());
 
         // then
-        assertThat(response.getGroupMembers()).hasSize(2);
+        assertThat(response.getGroupMembers()).hasSize(1);
     }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
@@ -1,5 +1,7 @@
 package com.twtw.backend.domain.group.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
 import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
 import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
@@ -13,13 +15,12 @@ import com.twtw.backend.domain.group.repository.GroupRepository;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.service.LoginTest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("GroupService의")
 class GroupServiceTest extends LoginTest {

--- a/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
@@ -1,17 +1,5 @@
 package com.twtw.backend.domain.plan.controller;
 
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.member.dto.response.MemberResponse;
 import com.twtw.backend.domain.place.entity.CategoryGroupCode;
@@ -25,7 +13,6 @@ import com.twtw.backend.domain.plan.dto.response.PlanInfoResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanResponse;
 import com.twtw.backend.domain.plan.service.PlanService;
 import com.twtw.backend.support.docs.RestDocsTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -36,6 +23,17 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("PlanController의")
 @WebMvcTest(PlanController.class)
@@ -196,11 +194,10 @@ class PlanControllerTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("계획 참여 API가 수행되는가")
+    @DisplayName("계획 초대 API가 수행되는가")
     void joinPlan() throws Exception {
         // given
-        final PlanResponse expected = new PlanResponse(UUID.randomUUID(), UUID.randomUUID());
-        given(planService.joinPlan(any())).willReturn(expected);
+        willDoNothing().given(planService).joinPlan(any());
 
         // when
         final ResultActions perform =
@@ -209,26 +206,67 @@ class PlanControllerTest extends RestDocsTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(
                                         toRequestBody(
-                                                new SavePlanRequest(
-                                                        UUID.randomUUID(),
-                                                        LocalDateTime.of(2023, 12, 25, 13, 30),
-                                                        new PlaceDetails(
-                                                                "이디야커피 안성죽산점",
-                                                                "http://place.map.kakao.com/1562566188",
-                                                                "경기 안성시 죽산면 죽주로 287-1",
-                                                                127.426865189637,
-                                                                37.0764635355795))))
+                                                new PlanMemberRequest(UUID.randomUUID())))
                                 .header(
                                         "Authorization",
                                         "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
         // then
-        perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.planId").isString())
-                .andExpect(jsonPath("$.groupId").isString());
+        perform.andExpect(status().isNoContent());
 
         // docs
         perform.andDo(print())
                 .andDo(document("post join plan", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("계획 참여 API가 수행되는가")
+    void invitePlan() throws Exception {
+        // given
+        final PlanResponse expected = new PlanResponse(UUID.randomUUID(), UUID.randomUUID());
+        given(planService.invitePlan(any())).willReturn(expected);
+
+        // when
+        final ResultActions perform =
+                mockMvc.perform(
+                        post("/plans/invite")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        toRequestBody(
+                                                new PlanMemberRequest(UUID.randomUUID())))
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+        // then
+        perform.andExpect(status().isOk());
+
+        // docs
+        perform.andDo(print())
+                .andDo(document("post invite plan", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("계획 초대 삭제 API가 수행되는가")
+    void deleteInvite() throws Exception {
+        // given
+        willDoNothing().given(planService).deletePlan(any());
+
+        // when
+        final ResultActions perform =
+                mockMvc.perform(
+                        delete("/plans/invite")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        toRequestBody(
+                                                new PlanMemberRequest(UUID.randomUUID())))
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+        // then
+        perform.andExpect(status().isNoContent());
+
+        // docs
+        perform.andDo(print())
+                .andDo(document("delete plan invite", getDocumentRequest(), getDocumentResponse()));
     }
 
     @Test

--- a/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/controller/PlanControllerTest.java
@@ -1,5 +1,17 @@
 package com.twtw.backend.domain.plan.controller;
 
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.twtw.backend.domain.group.dto.response.GroupInfoResponse;
 import com.twtw.backend.domain.member.dto.response.MemberResponse;
 import com.twtw.backend.domain.place.entity.CategoryGroupCode;
@@ -13,6 +25,7 @@ import com.twtw.backend.domain.plan.dto.response.PlanInfoResponse;
 import com.twtw.backend.domain.plan.dto.response.PlanResponse;
 import com.twtw.backend.domain.plan.service.PlanService;
 import com.twtw.backend.support.docs.RestDocsTest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -23,17 +36,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("PlanController의")
 @WebMvcTest(PlanController.class)
@@ -204,9 +206,7 @@ class PlanControllerTest extends RestDocsTest {
                 mockMvc.perform(
                         post("/plans/join")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(
-                                        toRequestBody(
-                                                new PlanMemberRequest(UUID.randomUUID())))
+                                .content(toRequestBody(new PlanMemberRequest(UUID.randomUUID())))
                                 .header(
                                         "Authorization",
                                         "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
@@ -230,9 +230,7 @@ class PlanControllerTest extends RestDocsTest {
                 mockMvc.perform(
                         post("/plans/invite")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(
-                                        toRequestBody(
-                                                new PlanMemberRequest(UUID.randomUUID())))
+                                .content(toRequestBody(new PlanMemberRequest(UUID.randomUUID())))
                                 .header(
                                         "Authorization",
                                         "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
@@ -255,9 +253,7 @@ class PlanControllerTest extends RestDocsTest {
                 mockMvc.perform(
                         delete("/plans/invite")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(
-                                        toRequestBody(
-                                                new PlanMemberRequest(UUID.randomUUID())))
+                                .content(toRequestBody(new PlanMemberRequest(UUID.randomUUID())))
                                 .header(
                                         "Authorization",
                                         "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));

--- a/backend/src/test/java/com/twtw/backend/domain/plan/service/PlanServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/service/PlanServiceTest.java
@@ -1,5 +1,7 @@
 package com.twtw.backend.domain.plan.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.twtw.backend.domain.group.repository.GroupRepository;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.place.entity.CategoryGroupCode;
@@ -16,6 +18,7 @@ import com.twtw.backend.fixture.place.PlaceDetailsFixture;
 import com.twtw.backend.fixture.place.PlaceEntityFixture;
 import com.twtw.backend.fixture.plan.PlanEntityFixture;
 import com.twtw.backend.support.service.LoginTest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,8 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("PlanService의")
 class PlanServiceTest extends LoginTest {

--- a/backend/src/test/java/com/twtw/backend/domain/plan/service/PlanServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/service/PlanServiceTest.java
@@ -1,7 +1,5 @@
 package com.twtw.backend.domain.plan.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.twtw.backend.domain.group.repository.GroupRepository;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.place.entity.CategoryGroupCode;
@@ -18,7 +16,6 @@ import com.twtw.backend.fixture.place.PlaceDetailsFixture;
 import com.twtw.backend.fixture.place.PlaceEntityFixture;
 import com.twtw.backend.fixture.plan.PlanEntityFixture;
 import com.twtw.backend.support.service.LoginTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("PlanService의")
 class PlanServiceTest extends LoginTest {
@@ -83,7 +82,9 @@ class PlanServiceTest extends LoginTest {
         final UUID planId = plan.getId();
 
         // when
-        planService.joinPlan(new PlanMemberRequest(planId));
+        planService.invitePlan(new PlanMemberRequest(planId));
+        plan.acceptInvite(loginUser);
+        plan.acceptInvite(member);
 
         // then
         final Plan result = planRepository.findById(planId).orElseThrow();


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 그룹, 계획 초대 중복 제거
- 초대 승락/삭제 api 추가

## 특이사항
- api docs 참고하기

## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
