### PR TITLE
[FEAT] redis 을 통한 lock 적용과 api 캐싱 및 test container 적용

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,11 +1,11 @@
 name: TWTW Backend CD
-on:
-  workflow_run:
-    branches:
-      - "master"
-    workflows: ["TWTW Backend CI", "TWTW Nginx Build"]
-    types:
-      - completed
+# on:
+#   workflow_run:
+#     branches:
+#      - "master"
+#     workflows: ["TWTW Backend CI", "TWTW Nginx Build"]
+#     types:
+#      - completed
 
 jobs:
   server-deploy:

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,11 +1,11 @@
 name: TWTW Backend CD
-# on:
-#   workflow_run:
-#     branches:
-#      - "master"
-#     workflows: ["TWTW Backend CI", "TWTW Nginx Build"]
-#     types:
-#      - completed
+on:
+  workflow_run:
+    branches:
+     - "master"
+    workflows: ["TWTW Backend CI", "TWTW Nginx Build"]
+    types:
+     - completed
 
 jobs:
   server-deploy:
@@ -14,23 +14,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Copy docker-compose file to server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.AWS_IP }}
-          username: ubuntu
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "./docker-compose.prod.yml"
-          target: "/var/www/TWTW"
+      # - name: Copy docker-compose file to server
+      #   uses: appleboy/scp-action@master
+      #   with:
+      #     host: ${{ secrets.AWS_IP }}
+      #     username: ubuntu
+      #     key: ${{ secrets.SSH_PRIVATE_KEY }}
+      #     source: "./docker-compose.prod.yml"
+      #     target: "/var/www/TWTW"
 
-      - name: Deploy using docker-compose
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.AWS_IP }}
-          username: ubuntu
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            cd /var/www/TWTW
-            sudo docker-compose down
-            sudo docker-compose pull
-            sudo docker-compose up -d
+      # - name: Deploy using docker-compose
+      #   uses: appleboy/ssh-action@master
+      #   with:
+      #     host: ${{ secrets.AWS_IP }}
+      #     username: ubuntu
+      #     key: ${{ secrets.SSH_PRIVATE_KEY }}
+      #     script: |
+      #       cd /var/www/TWTW
+      #       sudo docker-compose down
+      #       sudo docker-compose pull
+      #       sudo docker-compose up -d

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -47,7 +47,7 @@ jobs:
       uses: madrapps/jacoco-report@v1.2
       with:
         paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.FLOWS_PAT }}
         title: "Test Coverage"
         min-coverage-overall: 50
         min-coverage-changed-files: 50

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -42,14 +42,11 @@ jobs:
     - run: ./gradlew build
     - run: ./gradlew jib
 
-    - name: Verify JaCoCo Test Report
-      run: ls -l build/reports/jacoco/test
-
     - name: Check test coverage
       id: jacoco
       uses: madrapps/jacoco-report@v1.2
       with:
-        paths: build/reports/jacoco/test/jacocoTestReport.xml
+        paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
         token: ${{ secrets.GITHUB_TOKEN }}
         title: "Test Coverage"
         min-coverage-overall: 50

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -50,8 +50,8 @@ jobs:
         chmod 644 src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
         chmod +x gradlew
         find src
-        ./gradlew build
-
+      
+    - run: ./gradlew build
     - run: ./gradlew jib
 
     - name: Test Coverage Report

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -33,13 +33,12 @@ jobs:
       run: |
         mkdir -p src/test/resources
         mkdir -p src/main/resources
-        echo "${{ secrets.ENVIRONMENT }}" | base64 --decode > src/test/resources/application-env.yml
-        echo "${{ secrets.ENVIRONMENT }}" | base64 --decode > src/main/resources/application-env.yml
-        echo "${{ secrets.FIREBASE_JSON }}" | base64 --decode > src/test/resources/twtw_firebase_key.json
-        echo "${{ secrets.FIREBASE_JSON }}" | base64 --decode > src/main/resources/twtw_firebase_key.json
-        echo "${{ secrets.STORAGE_JSON }}" | base64 --decode > src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
-        echo "${{ secrets.STORAGE_JSON }}" | base64 --decode > src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
-        find src
+        echo "${{ secrets.ENVIRONMENT_YML }}" > src/test/resources/application-env.yml
+        echo "${{ secrets.ENVIRONMENT_YML }}" > src/main/resources/application-env.yml
+        echo "${{ secrets.FIREBASE_JSON }}" > src/test/resources/twtw_firebase_key.json
+        echo "${{ secrets.FIREBASE_JSON }}" > src/main/resources/twtw_firebase_key.json
+        echo "${{ secrets.STORAGE_JSON }}" > src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
+        echo "${{ secrets.STORAGE_JSON }}" > src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
 
     - run: chmod +x gradlew
     - run: ./gradlew build -x test

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -49,6 +49,7 @@ jobs:
       uses: madrapps/jacoco-report@v1.2
       with:
         paths: build/reports/jacoco/test/jacocoTestReport.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
         title: "Test Coverage"
         min-coverage-overall: 50
         min-coverage-changed-files: 50

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,14 +35,15 @@ jobs:
         mkdir -p src/main/resources
         echo "${{ secrets.ENVIRONMENT_YML }}" > src/test/resources/application-env.yml
         echo "${{ secrets.ENVIRONMENT_YML }}" > src/main/resources/application-env.yml
-        echo "${{ secrets.FIREBASE_JSON }}" > src/test/resources/twtw_firebase_key.json
-        echo "${{ secrets.FIREBASE_JSON }}" > src/main/resources/twtw_firebase_key.json
         echo "${{ secrets.STORAGE_JSON }}" > src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
         echo "${{ secrets.STORAGE_JSON }}" > src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
     
     - run: chmod +x gradlew
     - run: ./gradlew build
     - run: ./gradlew jib
+
+    - name: Verify JaCoCo Test Report
+      run: ls -l build/reports/jacoco/test
 
     - name: Check test coverage
       id: jacoco

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -37,6 +37,7 @@ jobs:
 
     - run: chmod +x gradlew
     - run: ./gradlew build -x test
+    - run: ./gradlew test jacocoTestReport
     - run: ./gradlew jib
 
     - name: Test Coverage Report

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,8 +32,13 @@ jobs:
     - name: Apply Environment Variables
       run: |
         mkdir -p src/test/resources
+        mkdir -p src/main/resources
         echo "${{ secrets.ENVIRONMENT }}" | base64 --decode > src/test/resources/application-env.yml
         echo "${{ secrets.ENVIRONMENT }}" | base64 --decode > src/main/resources/application-env.yml
+        echo "${{ secrets.FIREBASE_JSON }}" | base64 --decode > src/test/resources/twtw_firebase_key.json
+        echo "${{ secrets.FIREBASE_JSON }}" | base64 --decode > src/main/resources/twtw_firebase_key.json
+        echo "${{ secrets.STORAGE_JSON }}" | base64 --decode > src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
+        echo "${{ secrets.STORAGE_JSON }}" | base64 --decode > src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
         find src
 
     - run: chmod +x gradlew
@@ -48,5 +53,5 @@ jobs:
         paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
         token: ${{ secrets.GITHUB_TOKEN }}
         title: "test coverage"
-        min-coverage-overall: 60
-        min-coverage-changed-files: 60
+        min-coverage-overall: 50
+        min-coverage-changed-files: 50

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -44,12 +44,11 @@ jobs:
     - run: ./gradlew build
     - run: ./gradlew jib
 
-    - name: Test Coverage Report
+    - name: Check test coverage
       id: jacoco
       uses: madrapps/jacoco-report@v1.2
       with:
-        paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
-        token: ${{ secrets.GITHUB_TOKEN }}
-        title: "test coverage"
+        paths: build/reports/jacoco/test/jacocoTestReport.xml
+        title: "Test Coverage"
         min-coverage-overall: 50
         min-coverage-changed-files: 50

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -40,17 +40,7 @@ jobs:
         echo "${{ secrets.STORAGE_JSON }}" > src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
         echo "${{ secrets.STORAGE_JSON }}" > src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
     
-    - name: Set File Permissions
-      run: |
-        chmod 644 src/test/resources/application-env.yml
-        chmod 644 src/main/resources/application-env.yml
-        chmod 644 src/test/resources/twtw_firebase_key.json
-        chmod 644 src/main/resources/twtw_firebase_key.json
-        chmod 644 src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
-        chmod 644 src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
-        chmod +x gradlew
-        find src
-      
+    - run: chmod +x gradlew
     - run: ./gradlew build
     - run: ./gradlew jib
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -50,8 +50,7 @@ jobs:
         chmod 644 src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
 
     - run: chmod +x gradlew
-    - run: ./gradlew build -x test
-    - run: ./gradlew test jacocoTestReport
+    - run: ./gradlew build
     - run: ./gradlew jib
 
     - name: Test Coverage Report

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -43,7 +43,7 @@ jobs:
       id: jacoco
       uses: madrapps/jacoco-report@v1.2
       with:
-        paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+        paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
         token: ${{ secrets.GITHUB_TOKEN }}
         title: "test coverage"
         min-coverage-overall: 60

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Apply Environment Variables
       run: |

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -48,9 +48,10 @@ jobs:
         chmod 644 src/main/resources/twtw_firebase_key.json
         chmod 644 src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
         chmod 644 src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
+        chmod +x gradlew
+        find src
+        ./gradlew build
 
-    - run: chmod +x gradlew
-    - run: ./gradlew build
     - run: ./gradlew jib
 
     - name: Test Coverage Report

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -39,6 +39,15 @@ jobs:
         echo "${{ secrets.FIREBASE_JSON }}" > src/main/resources/twtw_firebase_key.json
         echo "${{ secrets.STORAGE_JSON }}" > src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
         echo "${{ secrets.STORAGE_JSON }}" > src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
+    
+    - name: Set File Permissions
+      run: |
+        chmod 644 src/test/resources/application-env.yml
+        chmod 644 src/main/resources/application-env.yml
+        chmod 644 src/test/resources/twtw_firebase_key.json
+        chmod 644 src/main/resources/twtw_firebase_key.json
+        chmod 644 src/test/resources/engaged-shade-405207-b8ba9bb8a30f.json
+        chmod 644 src/main/resources/engaged-shade-405207-b8ba9bb8a30f.json
 
     - run: chmod +x gradlew
     - run: ./gradlew build -x test

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Apply Environment Variables
       run: |
         mkdir -p src/test/resources
+        echo "${{ secrets.ENVIRONMENT }}" | base64 --decode > src/test/resources/application-env.yml
         echo "${{ secrets.ENVIRONMENT }}" | base64 --decode > src/main/resources/application-env.yml
         find src
 

--- a/.github/workflows/nginx-build.yml
+++ b/.github/workflows/nginx-build.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Nginx Build and Push
       run: |
-        docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/twtw-nginx:latest ./nginx
-        docker push ${{ secrets.DOCKERHUB_USERNAME }}/twtw-nginx:latest
+        docker build -t ${{ secrets.DOCKER_USERNAME }}/twtw-nginx:latest ./nginx
+        docker push ${{ secrets.DOCKER_USERNAME }}/twtw-nginx:latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 backend/src/main/resources/application-env.yml
 .env
 secret.yml
+data/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -44,3 +44,4 @@ out/
 
 *.html
 application-env.yml
+*.json

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -109,6 +109,7 @@ tasks.named('test') {
 					 "com/twtw/backend/config/**",
 					 "com/twtw/backend/global/**",
 					 "com/twtw/backend/aspect/**",
+					 "com/twtw/backend/domain/**/exception/**",
 					 "com/twtw/backend/domain/**/controller/advice/**",
 					 "com/twtw/backend/domain/**/dto/**"]
 	}
@@ -131,6 +132,7 @@ jacocoTestReport {
 										"com/twtw/backend/config/**",
 										"com/twtw/backend/global/**",
 										"com/twtw/backend/aspect/**",
+										"com/twtw/backend/domain/**/exception/**",
 										"com/twtw/backend/domain/**/controller/advice/**",
 										"com/twtw/backend/domain/**/dto/**"])
 		}))

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -104,15 +104,7 @@ tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
 
-	jacoco {
-		excludes += ["com/twtw/backend/BackendApplication.class",
-					 "com/twtw/backend/config/**",
-					 "com/twtw/backend/global/**",
-					 "com/twtw/backend/aspect/**",
-					 "com/twtw/backend/domain/**/exception/**",
-					 "com/twtw/backend/domain/**/controller/advice/**",
-					 "com/twtw/backend/domain/**/dto/**"]
-	}
+	finalizedBy 'jacocoTestReport'
 }
 
 jacoco {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.5.RELEASE'
 	implementation 'com.google.firebase:firebase-admin:6.8.1'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'
 
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
+
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.5.RELEASE'
 	implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.5.RELEASE'
@@ -83,6 +86,10 @@ dependencies {
 	testImplementation 'org.springframework.amqp:spring-rabbit-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation "org.testcontainers:junit-jupiter:1.19.7"
+	testImplementation "org.testcontainers:junit-jupiter:1.19.7"
+	testImplementation "com.redis:testcontainers-redis:2.0.1"
+	testImplementation "org.testcontainers:rabbitmq:1.19.7"
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-gcp-storage:1.2.5.RELEASE'
 	implementation 'com.google.firebase:firebase-admin:6.8.1'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-	implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'
+	implementation 'org.redisson:redisson-spring-data-30:3.27.1'
 
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
+	implementation 'io.github.resilience4j:resilience4j-spring-boot2:2.2.0'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/backend/src/docs/friend.adoc
+++ b/backend/src/docs/friend.adoc
@@ -14,8 +14,17 @@ operation::post update friend status[snippets='http-request,http-response']
 === 친구 검색
 operation::get search friend[snippets='http-request,http-response']
 
+=== 친구 검색 cache
+operation::get search friend with cache[snippets='http-request,http-response']
+
 === 친구 전체 조회
 operation::get all friends[snippets='http-request,http-response']
 
+=== 친구 전체 조회 cache
+operation::get all friends with cache[snippets='http-request,http-response']
+
 === 친구 상태별 조회
 operation::get friends by status[snippets='http-request,http-response']
+
+=== 친구 상태별 조회 cache
+operation::get friends by status with cache[snippets='http-request,http-response']

--- a/backend/src/main/java/com/twtw/backend/aspect/DistributedLockAspect.java
+++ b/backend/src/main/java/com/twtw/backend/aspect/DistributedLockAspect.java
@@ -1,0 +1,65 @@
+package com.twtw.backend.aspect;
+
+import com.twtw.backend.global.lock.DistributedLock;
+import com.twtw.backend.utils.SpringELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+    private static final String INTERRUPTED_EXCEPTION = "INTERRUPTED EXCEPTION";
+    private static final String UNLOCK_EXCEPTION = "UNLOCK EXCEPTION";
+
+    private final RedissonClient redissonClient;
+    private final TransactionAspect transactionAspect;
+    private final SpringELParser springELParser;
+
+    @Around("@annotation(com.twtw.backend.global.lock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key =
+                REDISSON_LOCK_PREFIX
+                        + springELParser.getDynamicValue(
+                        signature.getParameterNames(),
+                        joinPoint.getArgs(),
+                        distributedLock.name());
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available =
+                    rLock.tryLock(
+                            distributedLock.waitTime(),
+                            distributedLock.leaseTime(),
+                            distributedLock.timeUnit());
+            if (!available) {
+                return false;
+            }
+            return transactionAspect.proceed(joinPoint);
+        } catch (final InterruptedException e) {
+            log.error(INTERRUPTED_EXCEPTION, e);
+            throw e;
+        } finally {
+            try {
+                rLock.unlock();
+            } catch (final Exception e) {
+                log.error(UNLOCK_EXCEPTION, e);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/aspect/TransactionAspect.java
+++ b/backend/src/main/java/com/twtw/backend/aspect/TransactionAspect.java
@@ -1,0 +1,14 @@
+package com.twtw.backend.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionAspect {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/config/circuitbreaker/Resilience4jConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/circuitbreaker/Resilience4jConfig.java
@@ -1,0 +1,15 @@
+package com.twtw.backend.config.circuitbreaker;
+
+import org.springframework.boot.actuate.health.SimpleStatusAggregator;
+import org.springframework.boot.actuate.health.StatusAggregator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Resilience4jConfig {
+
+    @Bean
+    public StatusAggregator statusAggregator() {
+        return new SimpleStatusAggregator();
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
@@ -5,14 +5,10 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.twtw.backend.global.properties.FirebaseProperties;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
-
-import java.io.IOException;
 
 @Configuration
 @RequiredArgsConstructor
@@ -35,8 +31,8 @@ public class FcmConfig {
                 return FirebaseApp.initializeApp(options);
             }
             return FirebaseApp.getInstance();
-        } catch (final IOException ignored) {
-            return null;
+        } catch (final Exception e) {
+            return FirebaseApp.initializeApp();
         }
     }
 

--- a/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
@@ -6,38 +6,35 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.twtw.backend.global.properties.FirebaseProperties;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
 
 @Configuration
 @RequiredArgsConstructor
 public class FcmConfig {
 
     private final FirebaseProperties firebaseProperties;
+    private final ApplicationContext context;
 
     @Bean
-    public FirebaseApp firebaseApp() {
-        try {
-            final FirebaseOptions options =
-                    new FirebaseOptions.Builder()
-                            .setCredentials(
-                                    GoogleCredentials.fromStream(
-                                            new ClassPathResource(firebaseProperties.getLocation())
-                                                    .getInputStream()))
-                            .build();
+    public FirebaseApp firebaseApp() throws IOException {
+        final FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(
+                        context.getResource(firebaseProperties.getLocation()).getInputStream()))
+                .build();
 
-            if (FirebaseApp.getApps().isEmpty()) {
-                return FirebaseApp.initializeApp(options);
-            }
+        if (FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.initializeApp(options);
+        } else {
             return FirebaseApp.getInstance();
-        } catch (final Exception e) {
-            return FirebaseApp.initializeApp();
         }
     }
 
     @Bean
-    public FirebaseMessaging firebaseMessaging() {
+    public FirebaseMessaging firebaseMessaging() throws IOException {
         return FirebaseMessaging.getInstance(firebaseApp());
     }
 }

--- a/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
@@ -22,19 +22,14 @@ public class FcmConfig {
 
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
-        log.info("FirebaseApp initializing...11111");
-
         final FirebaseOptions options = new FirebaseOptions.Builder()
                 .setCredentials(GoogleCredentials.fromStream(
                         new ClassPathResource(firebaseProperties.getLocation()).getInputStream()))
                 .build();
-        log.info("FirebaseApp initializing...22222");
 
         if (FirebaseApp.getApps().isEmpty()) {
-            log.info("FirebaseApp initializing...33333");
             return FirebaseApp.initializeApp(options);
         }
-        log.info("FirebaseApp initializing...44444");
         return FirebaseApp.getInstance();
     }
 

--- a/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
@@ -21,23 +21,24 @@ public class FcmConfig {
     private final FirebaseProperties firebaseProperties;
 
     @Bean
-    public FirebaseApp firebaseApp() throws IOException {
-        FirebaseOptions options =
-                new FirebaseOptions.Builder()
-                        .setCredentials(
-                                GoogleCredentials.fromStream(
-                                        new ClassPathResource(firebaseProperties.getLocation())
-                                                .getInputStream()))
-                        .build();
-
-        if (FirebaseApp.getApps().isEmpty()) {
-            return FirebaseApp.initializeApp(options);
-        }
+    public FirebaseApp firebaseApp() {
+        try {
+            final FirebaseOptions options =
+                    new FirebaseOptions.Builder()
+                            .setCredentials(
+                                    GoogleCredentials.fromStream(
+                                            new ClassPathResource(firebaseProperties.getLocation())
+                                                    .getInputStream()))
+                            .build();
+            if (FirebaseApp.getApps().isEmpty()) {
+                return FirebaseApp.initializeApp(options);
+            }
+        } catch (IOException ignored) {}
         return FirebaseApp.getInstance();
     }
 
     @Bean
-    public FirebaseMessaging firebaseMessaging() throws IOException {
+    public FirebaseMessaging firebaseMessaging() {
         return FirebaseMessaging.getInstance(firebaseApp());
     }
 }

--- a/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
@@ -30,11 +30,14 @@ public class FcmConfig {
                                             new ClassPathResource(firebaseProperties.getLocation())
                                                     .getInputStream()))
                             .build();
+
             if (FirebaseApp.getApps().isEmpty()) {
                 return FirebaseApp.initializeApp(options);
             }
-        } catch (IOException ignored) {}
-        return FirebaseApp.getInstance();
+            return FirebaseApp.getInstance();
+        } catch (final IOException ignored) {
+            return null;
+        }
     }
 
     @Bean

--- a/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
@@ -6,31 +6,36 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.twtw.backend.global.properties.FirebaseProperties;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class FcmConfig {
 
     private final FirebaseProperties firebaseProperties;
-    private final ApplicationContext context;
 
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
+        log.info("FirebaseApp initializing...11111");
+
         final FirebaseOptions options = new FirebaseOptions.Builder()
                 .setCredentials(GoogleCredentials.fromStream(
-                        context.getResource(firebaseProperties.getLocation()).getInputStream()))
+                        new ClassPathResource(firebaseProperties.getLocation()).getInputStream()))
                 .build();
+        log.info("FirebaseApp initializing...22222");
 
         if (FirebaseApp.getApps().isEmpty()) {
+            log.info("FirebaseApp initializing...33333");
             return FirebaseApp.initializeApp(options);
-        } else {
-            return FirebaseApp.getInstance();
         }
+        log.info("FirebaseApp initializing...44444");
+        return FirebaseApp.getInstance();
     }
 
     @Bean

--- a/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/firebase/FcmConfig.java
@@ -1,5 +1,6 @@
 package com.twtw.backend.config.firebase;
 
+import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -9,9 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
-
-import java.io.IOException;
 
 @Slf4j
 @Configuration
@@ -21,10 +19,9 @@ public class FcmConfig {
     private final FirebaseProperties firebaseProperties;
 
     @Bean
-    public FirebaseApp firebaseApp() throws IOException {
+    public FirebaseApp firebaseApp() {
         final FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(
-                        new ClassPathResource(firebaseProperties.getLocation()).getInputStream()))
+                .setCredentials(GoogleCredentials.create(new AccessToken(firebaseProperties.getKey(), null)))
                 .build();
 
         if (FirebaseApp.getApps().isEmpty()) {
@@ -34,7 +31,7 @@ public class FcmConfig {
     }
 
     @Bean
-    public FirebaseMessaging firebaseMessaging() throws IOException {
+    public FirebaseMessaging firebaseMessaging() {
         return FirebaseMessaging.getInstance(firebaseApp());
     }
 }

--- a/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
@@ -3,9 +3,7 @@ package com.twtw.backend.config.rabbitmq;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.twtw.backend.global.constant.RabbitMQConstant;
 import com.twtw.backend.global.properties.RabbitMQProperties;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
@@ -18,9 +16,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
-@Profile("!test")
 @EnableRabbit
 @Configuration
 @RequiredArgsConstructor
@@ -80,7 +76,7 @@ public class RabbitMQConfig {
 
     @Bean
     public RabbitTemplate rabbitTemplate() {
-        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory());
+        final RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory());
         rabbitTemplate.setMessageConverter(jsonMessageConverter());
         return rabbitTemplate;
     }

--- a/backend/src/main/java/com/twtw/backend/config/redis/RedisConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/redis/RedisConfig.java
@@ -1,9 +1,11 @@
 package com.twtw.backend.config.redis;
 
 import com.twtw.backend.global.properties.RedisProperties;
-
 import lombok.RequiredArgsConstructor;
-
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.spring.data.connection.RedissonConnectionFactory;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +13,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -26,11 +27,25 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class RedisConfig {
     private static final Long TIME_TO_LIVE = 1L;
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+    private static final String URL_DELIMITER = ":";
     private final RedisProperties redisProperties;
 
     @Bean
+    public RedissonClient redissonClient() {
+        final Config config = new Config();
+        config.useSingleServer()
+                .setAddress(
+                        REDISSON_HOST_PREFIX
+                                + redisProperties.getHost()
+                                + URL_DELIMITER
+                                + redisProperties.getPort());
+        return Redisson.create(config);
+    }
+
+    @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+        return new RedissonConnectionFactory(redissonClient());
     }
 
     @Bean

--- a/backend/src/main/java/com/twtw/backend/config/socket/StompConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/socket/StompConfig.java
@@ -1,18 +1,14 @@
 package com.twtw.backend.config.socket;
 
 import com.twtw.backend.global.properties.RabbitMQProperties;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-@Profile("!test")
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSocketMessageBroker

--- a/backend/src/main/java/com/twtw/backend/config/web/WebConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/web/WebConfig.java
@@ -1,12 +1,14 @@
 package com.twtw.backend.config.web;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
@@ -23,11 +25,14 @@ public class WebConfig extends WebMvcConfigurationSupport {
         super.configureMessageConverters(converters);
     }
 
-    private ObjectMapper objectMapper() {
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
         return new ObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
                 .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, true)
+                .configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true)
                 .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
                 .registerModule(new JavaTimeModule());
     }

--- a/backend/src/main/java/com/twtw/backend/domain/friend/controller/FriendController.java
+++ b/backend/src/main/java/com/twtw/backend/domain/friend/controller/FriendController.java
@@ -25,10 +25,21 @@ public class FriendController {
         return ResponseEntity.ok(friendService.getFriends());
     }
 
+    @GetMapping("all/cache")
+    public ResponseEntity<List<FriendResponse>> getFriendsWithCache() {
+        return ResponseEntity.ok(friendService.getFriendsWithCache());
+    }
+
     @GetMapping
     public ResponseEntity<List<FriendResponse>> getFriendsByStatus(
             @RequestParam final FriendStatus friendStatus) {
         return ResponseEntity.ok(friendService.getFriendsByStatus(friendStatus));
+    }
+
+    @GetMapping("cache")
+    public ResponseEntity<List<FriendResponse>> getFriendsByStatusWithCache(
+            @RequestParam final FriendStatus friendStatus) {
+        return ResponseEntity.ok(friendService.getFriendsByStatusWithCache(friendStatus));
     }
 
     @PostMapping("request")
@@ -48,5 +59,11 @@ public class FriendController {
     public ResponseEntity<List<FriendResponse>> getFriendByName(
             @RequestParam final String nickname) {
         return ResponseEntity.ok(friendService.getFriendByNickname(nickname));
+    }
+
+    @GetMapping("search/cache")
+    public ResponseEntity<List<FriendResponse>> getFriendByNameWithCache(
+            @RequestParam final String nickname) {
+        return ResponseEntity.ok(friendService.getFriendByNicknameWithCache(nickname));
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/friend/dto/response/FriendResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/friend/dto/response/FriendResponse.java
@@ -3,11 +3,13 @@ package com.twtw.backend.domain.friend.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.UUID;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor
 public class FriendResponse {
     private UUID memberId;

--- a/backend/src/main/java/com/twtw/backend/domain/friend/repository/FriendQueryRepository.java
+++ b/backend/src/main/java/com/twtw/backend/domain/friend/repository/FriendQueryRepository.java
@@ -16,4 +16,6 @@ public interface FriendQueryRepository {
     List<Friend> findByMemberAndFriendStatus(final Member member, final FriendStatus friendStatus);
 
     List<Friend> findByMemberAndMemberNickname(final Member member, final String nickname);
+
+    boolean existsByTwoMemberId(final UUID loginMemberId, final UUID memberId);
 }

--- a/backend/src/main/java/com/twtw/backend/domain/friend/repository/FriendQueryRepositoryImpl.java
+++ b/backend/src/main/java/com/twtw/backend/domain/friend/repository/FriendQueryRepositoryImpl.java
@@ -1,19 +1,18 @@
 package com.twtw.backend.domain.friend.repository;
 
-import static com.twtw.backend.domain.friend.entity.QFriend.friend;
-
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.twtw.backend.domain.friend.entity.Friend;
 import com.twtw.backend.domain.friend.entity.FriendStatus;
 import com.twtw.backend.domain.member.entity.Member;
-
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static com.twtw.backend.domain.friend.entity.QFriend.friend;
 
 @Repository
 @RequiredArgsConstructor
@@ -81,5 +80,26 @@ public class FriendQueryRepositoryImpl implements FriendQueryRepository {
                                                                                 .containsIgnoreCase(
                                                                                         nickname)))))
                 .fetch();
+    }
+
+    @Override
+    public boolean existsByTwoMemberId(final UUID loginMemberId, final UUID memberId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(friend)
+                        .setLockMode(LockModeType.PESSIMISTIC_READ)
+                        .setHint("javax.persistence.lock.timeout", 3)
+                        .where(
+                                (friend.toMember
+                                        .id
+                                        .eq(loginMemberId)
+                                        .and(friend.fromMember.id.eq(memberId))
+                                        .or(
+                                                friend.fromMember
+                                                        .id
+                                                        .eq(loginMemberId)
+                                                        .and(friend.toMember.id.eq(memberId)))))
+                        .fetchFirst())
+                .isPresent();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/friend/service/FriendService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/friend/service/FriendService.java
@@ -17,6 +17,7 @@ import com.twtw.backend.global.constant.NotificationTitle;
 import com.twtw.backend.global.exception.EntityNotFoundException;
 import com.twtw.backend.global.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -80,6 +81,10 @@ public class FriendService {
                 .orElseThrow(EntityNotFoundException::new);
     }
 
+    @CacheEvict(
+            value = "getFriendsWithCache",
+            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue())",
+            cacheManager = "cacheManager")
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriends() {
         return getFriendResponses();
@@ -105,6 +110,10 @@ public class FriendService {
         return friendMapper.toResponses(friends);
     }
 
+    @CacheEvict(
+            value = "getFriendsByStatusWithCache",
+            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue()).concat(#friendStatus.name())",
+            cacheManager = "cacheManager")
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriendsByStatus(final FriendStatus friendStatus) {
         return getFriendResponsesByStatus(friendStatus);
@@ -130,6 +139,10 @@ public class FriendService {
         return friendMapper.toResponses(friends);
     }
 
+    @CacheEvict(
+            value = "getFriendsByNicknameWithCache",
+            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue()).concat(#nickname)",
+            cacheManager = "cacheManager")
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriendByNickname(final String nickname) {
         return getFriendResponsesByNickname(nickname);

--- a/backend/src/main/java/com/twtw/backend/domain/friend/service/FriendService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/friend/service/FriendService.java
@@ -15,9 +15,9 @@ import com.twtw.backend.domain.notification.messagequeue.FcmProducer;
 import com.twtw.backend.global.constant.NotificationBody;
 import com.twtw.backend.global.constant.NotificationTitle;
 import com.twtw.backend.global.exception.EntityNotFoundException;
-
+import com.twtw.backend.global.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,13 +33,28 @@ public class FriendService {
     private final AuthService authService;
     private final FcmProducer fcmProducer;
 
+    @Transactional
     public void addRequest(final FriendRequest friendRequest) {
         final Member loginMember = authService.getMemberByJwt();
         final Member member = memberService.getMemberById(friendRequest.getMemberId());
-        friendRepository.save(friendMapper.toEntity(loginMember, member));
+
+        createFriendRequestByNicknameOrder(loginMember, member);
 
         sendNotification(
                 member.getDeviceTokenValue(), loginMember.getNickname(), loginMember.getId());
+    }
+
+    private void createFriendRequestByNicknameOrder(final Member loginMember, final Member member) {
+        if (loginMember.hasFasterNickname(member)) {
+            createFriendRequest(loginMember, member);
+            return;
+        }
+        createFriendRequest(member, loginMember);
+    }
+
+    @DistributedLock(name = "#fromMember.getNickname().concat(#toMember.getNickname())")
+    public void createFriendRequest(final Member fromMember, final Member toMember) {
+        friendRepository.save(friendMapper.toEntity(fromMember, toMember));
     }
 
     private void sendNotification(final String deviceToken, final String nickname, final UUID id) {
@@ -55,6 +70,7 @@ public class FriendService {
     public void updateStatus(final FriendUpdateRequest friendUpdateRequest) {
         final UUID loginMemberId = authService.getMemberByJwt().getId();
         final Friend friend = getFriendById(loginMemberId, friendUpdateRequest.getMemberId());
+
         friend.updateStatus(friendUpdateRequest.getFriendStatus());
     }
 
@@ -66,31 +82,76 @@ public class FriendService {
 
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriends() {
+        return getFriendResponses();
+    }
+
+    @Cacheable(
+            value = "getFriendsWithCache",
+            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue())",
+            cacheManager = "cacheManager",
+            unless = "#result.size() <= 0")
+    @Transactional(readOnly = true)
+    public List<FriendResponse> getFriendsWithCache() {
+        return getFriendResponses();
+    }
+
+    private List<FriendResponse> getFriendResponses() {
         final Member loginMember = authService.getMemberByJwt();
         final List<Member> friends =
                 friendRepository.findByMember(loginMember).stream()
                         .map(friend -> friend.getFriendMember(loginMember))
                         .toList();
+
         return friendMapper.toResponses(friends);
     }
 
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriendsByStatus(final FriendStatus friendStatus) {
+        return getFriendResponsesByStatus(friendStatus);
+    }
+
+    @Cacheable(
+            value = "getFriendsByStatusWithCache",
+            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue()).concat(#friendStatus.name())",
+            cacheManager = "cacheManager",
+            unless = "#result.size() <= 0")
+    @Transactional(readOnly = true)
+    public List<FriendResponse> getFriendsByStatusWithCache(final FriendStatus friendStatus) {
+        return getFriendResponsesByStatus(friendStatus);
+    }
+
+    private List<FriendResponse> getFriendResponsesByStatus(final FriendStatus friendStatus) {
         final Member loginMember = authService.getMemberByJwt();
         final List<Member> friends =
                 friendRepository.findByMemberAndFriendStatus(loginMember, friendStatus).stream()
                         .map(friend -> friend.getFriendMember(loginMember))
                         .toList();
+
         return friendMapper.toResponses(friends);
     }
 
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriendByNickname(final String nickname) {
+        return getFriendResponsesByNickname(nickname);
+    }
+
+    @Cacheable(
+            value = "getFriendsByNicknameWithCache",
+            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue()).concat(#nickname)",
+            cacheManager = "cacheManager",
+            unless = "#result.size() <= 0")
+    @Transactional(readOnly = true)
+    public List<FriendResponse> getFriendByNicknameWithCache(final String nickname) {
+        return getFriendResponsesByNickname(nickname);
+    }
+
+    private List<FriendResponse> getFriendResponsesByNickname(final String nickname) {
         final Member loginMember = authService.getMemberByJwt();
         final List<Member> friends =
                 friendRepository.findByMemberAndMemberNickname(loginMember, nickname).stream()
                         .map(friend -> friend.getFriendMember(loginMember))
                         .toList();
+
         return friendMapper.toResponses(friends);
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/friend/service/FriendService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/friend/service/FriendService.java
@@ -81,9 +81,13 @@ public class FriendService {
                 .orElseThrow(EntityNotFoundException::new);
     }
 
+    public String getMemberIdValue() {
+        return authService.getMemberIdValue();
+    }
+
     @CacheEvict(
             value = "getFriendsWithCache",
-            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue())",
+            key = "'getFriendsWithCache'.concat(#root.target.getMemberIdValue())",
             cacheManager = "cacheManager")
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriends() {
@@ -92,7 +96,7 @@ public class FriendService {
 
     @Cacheable(
             value = "getFriendsWithCache",
-            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue())",
+            key = "'getFriendsWithCache'.concat(#root.target.getMemberIdValue())",
             cacheManager = "cacheManager",
             unless = "#result.size() <= 0")
     @Transactional(readOnly = true)
@@ -112,7 +116,7 @@ public class FriendService {
 
     @CacheEvict(
             value = "getFriendsByStatusWithCache",
-            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue()).concat(#friendStatus.name())",
+            key = "'getFriendsWithCache'.concat(#root.target.getMemberIdValue()).concat(#friendStatus.name())",
             cacheManager = "cacheManager")
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriendsByStatus(final FriendStatus friendStatus) {
@@ -121,7 +125,7 @@ public class FriendService {
 
     @Cacheable(
             value = "getFriendsByStatusWithCache",
-            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue()).concat(#friendStatus.name())",
+            key = "'getFriendsWithCache'.concat(#root.target.getMemberIdValue()).concat(#friendStatus.name())",
             cacheManager = "cacheManager",
             unless = "#result.size() <= 0")
     @Transactional(readOnly = true)
@@ -141,7 +145,7 @@ public class FriendService {
 
     @CacheEvict(
             value = "getFriendsByNicknameWithCache",
-            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue()).concat(#nickname)",
+            key = "'getFriendsWithCache'.concat(#root.target.getMemberIdValue()).concat(#nickname)",
             cacheManager = "cacheManager")
     @Transactional(readOnly = true)
     public List<FriendResponse> getFriendByNickname(final String nickname) {
@@ -150,7 +154,7 @@ public class FriendService {
 
     @Cacheable(
             value = "getFriendsByNicknameWithCache",
-            key = "'getFriendsWithCache'.concat(#root.target.authService.getMemberIdValue()).concat(#nickname)",
+            key = "'getFriendsWithCache'.concat(#root.target.getMemberIdValue()).concat(#nickname)",
             cacheManager = "cacheManager",
             unless = "#result.size() <= 0")
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/twtw/backend/domain/image/service/ImageService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/image/service/ImageService.java
@@ -11,6 +11,7 @@ import com.twtw.backend.global.properties.StorageProperties;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ public class ImageService {
     private final Storage storage;
     private final StorageProperties storageProperties;
 
+    @Transactional
     public ImageResponse uploadImage(final MultipartFile image) throws IOException {
         final Member member = authService.getMemberByJwt();
         final String contentType = image.getContentType();

--- a/backend/src/main/java/com/twtw/backend/domain/location/service/GeoService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/location/service/GeoService.java
@@ -5,15 +5,12 @@ import com.twtw.backend.domain.location.dto.collection.MemberDistances;
 import com.twtw.backend.domain.location.dto.request.LocationRequest;
 import com.twtw.backend.domain.location.dto.response.AverageCoordinate;
 import com.twtw.backend.domain.member.entity.Member;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -24,7 +21,6 @@ public class GeoService {
     private static final Distance DEFAULT_DISTANCE = new Distance(0, Metrics.KILOMETERS);
     private final RedisTemplate<String, String> redisTemplate;
 
-    @Transactional
     public AverageCoordinate saveLocation(
             final Group group, final Member member, final LocationRequest locationRequest) {
         final String groupId = group.getId().toString();

--- a/backend/src/main/java/com/twtw/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/twtw/backend/domain/member/entity/Member.java
@@ -86,4 +86,8 @@ public class Member implements Auditable {
     public void removeGroupMember(final GroupMember groupMember) {
         this.groupMembers.remove(groupMember);
     }
+
+    public boolean hasFasterNickname(final Member member) {
+        return this.nickname.compareTo(member.nickname) < 0;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/member/service/AuthService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/member/service/AuthService.java
@@ -133,11 +133,15 @@ public class AuthService {
     }
 
     public Member getMemberByJwt() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberIdValue = getMemberIdValue();
 
-        UUID id = UUID.fromString(authentication.getName());
+        UUID id = UUID.fromString(memberIdValue);
 
         return memberRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+    }
+
+    public String getMemberIdValue() {
+        return SecurityContextHolder.getContext().getAuthentication().getName();
     }
 
     @Transactional

--- a/backend/src/main/java/com/twtw/backend/domain/path/client/SearchCarPathClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/client/SearchCarPathClient.java
@@ -6,6 +6,8 @@ import com.twtw.backend.global.client.NaverMapClient;
 import com.twtw.backend.global.exception.WebClientResponseException;
 import com.twtw.backend.global.properties.NaverProperties;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -14,6 +16,7 @@ import org.springframework.web.util.UriBuilder;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
+@Slf4j
 @Component
 public class SearchCarPathClient
         extends NaverMapClient<SearchCarPathRequest, SearchCarPathResponse> {
@@ -45,6 +48,7 @@ public class SearchCarPathClient
     }
 
     @Override
+    @CircuitBreaker(name = "backend-a", fallbackMethod = "fallback")
     public SearchCarPathResponse request(final SearchCarPathRequest request) {
         return webClient
                 .get()
@@ -57,5 +61,10 @@ public class SearchCarPathClient
                 .bodyToMono(SearchCarPathResponse.class)
                 .blockOptional()
                 .orElseThrow(WebClientResponseException::new);
+    }
+
+    public SearchCarPathResponse fallback(final Exception e) {
+        log.error("SearchCarPathClient fallback", e);
+        return SearchCarPathResponse.onError();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/client/SearchPedPathClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/client/SearchPedPathClient.java
@@ -6,6 +6,8 @@ import com.twtw.backend.global.client.TmapClient;
 import com.twtw.backend.global.exception.WebClientResponseException;
 import com.twtw.backend.global.properties.TmapProperties;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -14,6 +16,7 @@ import org.springframework.web.util.UriBuilder;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
+@Slf4j
 @Component
 public class SearchPedPathClient extends TmapClient<SearchPedPathRequest, SearchPedPathResponse> {
 
@@ -25,6 +28,7 @@ public class SearchPedPathClient extends TmapClient<SearchPedPathRequest, Search
     }
 
     @Override
+    @CircuitBreaker(name = "backend-a", fallbackMethod = "fallback")
     public SearchPedPathResponse request(SearchPedPathRequest request) {
         return webClient
                 .post()
@@ -41,5 +45,10 @@ public class SearchPedPathClient extends TmapClient<SearchPedPathRequest, Search
     private URI getPathUri(final UriBuilder uriBuilder) {
         final UriBuilder builder = uriBuilder.queryParam("version", 1.1);
         return builder.build();
+    }
+
+    public SearchPedPathResponse fallback(final Exception e) {
+        log.error("SearchPedPathClient fallback", e);
+        return SearchPedPathResponse.onError();
     }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/car/SearchCarPathResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/car/SearchCarPathResponse.java
@@ -12,8 +12,19 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SearchCarPathResponse {
+
+    private static final SearchCarPathResponse ON_ERROR_RESPONSE = new SearchCarPathResponse(
+            0,
+            "Internal Server Error",
+            "",
+            Map.of());
+
     private int code;
     private String message;
     private String currentDateTime;
     private Map<String, RouteUnitEnt[]> route;
+
+    public static SearchCarPathResponse onError() {
+        return ON_ERROR_RESPONSE;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/dto/client/ped/SearchPedPathResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/dto/client/ped/SearchPedPathResponse.java
@@ -12,6 +12,15 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SearchPedPathResponse {
+
+    private static final SearchPedPathResponse ON_ERROR_RESPONSE = new SearchPedPathResponse(
+            "",
+            List.of());
+
     private String type;
     private List<Feature> features;
+
+    public static SearchPedPathResponse onError() {
+        return ON_ERROR_RESPONSE;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/path/service/PathService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/path/service/PathService.java
@@ -23,7 +23,7 @@ public class PathService {
 
     @Cacheable(
             value = "carPath",
-            key = "{#request}",
+            key = "'searchCarPath'.concat(#request)",
             cacheManager = "cacheManager",
             unless = "#result.code != 0")
     public SearchCarPathResponse searchCarPath(final SearchCarPathRequest request) {
@@ -32,7 +32,7 @@ public class PathService {
 
     @Cacheable(
             value = "pedPath",
-            key = "{#request}",
+            key = "'searchPedPath'.concat(#request)",
             cacheManager = "cacheManager",
             unless = "#result.features.size() <= 0")
     public SearchPedPathResponse searchPedPath(final SearchPedPathRequest request) {

--- a/backend/src/main/java/com/twtw/backend/domain/place/dto/client/SurroundPlaceResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/place/dto/client/SurroundPlaceResponse.java
@@ -13,6 +13,15 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SurroundPlaceResponse {
+
+private static final SurroundPlaceResponse ON_ERROR_RESPONSE = new SurroundPlaceResponse(
+            new MetaDetails(true),
+            List.of());
+
     private MetaDetails meta;
     private List<PlaceClientDetails> documents;
+
+    public static SurroundPlaceResponse onError() {
+        return ON_ERROR_RESPONSE;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/place/service/PlaceService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/place/service/PlaceService.java
@@ -21,7 +21,7 @@ public class PlaceService {
 
     @Cacheable(
             value = "surroundPlace",
-            key = "{#surroundPlaceRequest}",
+            key = "'searchSurroundPlace'.concat(#surroundPlaceRequest)",
             cacheManager = "cacheManager",
             unless = "#result.results.size() <= 0")
     public PlaceResponse searchSurroundPlace(final SurroundPlaceRequest surroundPlaceRequest) {

--- a/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/client/SearchDestinationClient.java
@@ -5,7 +5,8 @@ import com.twtw.backend.domain.plan.dto.client.SearchDestinationRequest;
 import com.twtw.backend.domain.plan.dto.client.SearchDestinationResponse;
 import com.twtw.backend.global.client.KakaoMapClient;
 import com.twtw.backend.global.properties.KakaoProperties;
-
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -14,6 +15,7 @@ import org.springframework.web.util.UriBuilder;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
+@Slf4j
 @Component
 public class SearchDestinationClient
         extends KakaoMapClient<SearchDestinationRequest, SearchDestinationResponse> {
@@ -27,6 +29,7 @@ public class SearchDestinationClient
     }
 
     @Override
+    @CircuitBreaker(name = "backend-a", fallbackMethod = "fallback")
     public SearchDestinationResponse request(final SearchDestinationRequest request) {
         return webClient
                 .get()
@@ -37,6 +40,11 @@ public class SearchDestinationClient
                 .bodyToMono(SearchDestinationResponse.class)
                 .blockOptional()
                 .orElseGet(SearchDestinationResponse::new);
+    }
+
+    public SearchDestinationResponse fallback(final Exception e) {
+        log.error("SearchDestinationClient fallback", e);
+        return SearchDestinationResponse.onError();
     }
 
     private URI getUri(final SearchDestinationRequest request, final UriBuilder uriBuilder) {

--- a/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/SearchDestinationResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/dto/client/SearchDestinationResponse.java
@@ -10,6 +10,15 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SearchDestinationResponse {
+
+    private static final SearchDestinationResponse ON_ERROR_RESPONSE = new SearchDestinationResponse(
+            new MetaDetails(true),
+            List.of());
+
     private MetaDetails meta;
     private List<PlaceClientDetails> documents;
+
+    public static SearchDestinationResponse onError() {
+        return ON_ERROR_RESPONSE;
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
+++ b/backend/src/main/java/com/twtw/backend/domain/plan/service/PlanService.java
@@ -56,7 +56,7 @@ public class PlanService {
 
     @Cacheable(
             value = "planDestination",
-            key = "{#request}",
+            key = "'searchPlanDestination'.concat(#request)",
             cacheManager = "cacheManager",
             unless = "#result.results.size() <= 0")
     public PlanDestinationResponse searchPlanDestination(final SearchDestinationRequest request) {

--- a/backend/src/main/java/com/twtw/backend/global/advice/GlobalErrorAdvice.java
+++ b/backend/src/main/java/com/twtw/backend/global/advice/GlobalErrorAdvice.java
@@ -25,4 +25,9 @@ public class GlobalErrorAdvice {
     public ResponseEntity<ErrorResponse> authority(final AuthorityException e) {
         return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
     }
+
+    @ExceptionHandler(InterruptedException.class)
+    public ResponseEntity<ErrorResponse> interrupted(final InterruptedException e) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+    }
 }

--- a/backend/src/main/java/com/twtw/backend/global/lock/DistributedLock.java
+++ b/backend/src/main/java/com/twtw/backend/global/lock/DistributedLock.java
@@ -1,0 +1,19 @@
+package com.twtw.backend.global.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    String name();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 3L;
+
+    long leaseTime() default 5L;
+}

--- a/backend/src/main/java/com/twtw/backend/global/properties/FirebaseProperties.java
+++ b/backend/src/main/java/com/twtw/backend/global/properties/FirebaseProperties.java
@@ -9,5 +9,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "firebase")
 public class FirebaseProperties {
-    private final String location;
+    private final String key;
 }

--- a/backend/src/main/java/com/twtw/backend/utils/SpringELParser.java
+++ b/backend/src/main/java/com/twtw/backend/utils/SpringELParser.java
@@ -1,0 +1,23 @@
+package com.twtw.backend.utils;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringELParser {
+
+    private static final ExpressionParser PARSER = new SpelExpressionParser();
+    private static final Integer START_INDEX = 0;
+
+    public Object getDynamicValue(final String[] parameterNames, final Object[] args, final String key) {
+        final StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = START_INDEX; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return PARSER.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -6,13 +6,12 @@ spring:
     driver-class-name: org.mariadb.jdbc.Driver
     url: jdbc:mariadb://localhost:3306/TWTW
     username: root
-    password: root!
+    password: 1234
   jpa:
     database: mysql
-    generate-ddl: true
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         auto_quote_keyword: true
@@ -34,3 +33,9 @@ spring:
       port: 6379
   jackson:
     default-property-inclusion: non_null
+  flyway:
+    url: jdbc:mariadb://localhost:3306/TWTW
+    enabled: true
+    baseline-on-migrate: false
+    user: root
+    password: 1234

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -43,7 +43,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: *
+        include: ["metrics", "prometheus", "circuitbreakers", "circuitbreakerevents"]
   health:
     circuitbreakers:
       enabled: true

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -39,3 +39,8 @@ spring:
     baseline-on-migrate: false
     user: root
     password: 1234
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -43,4 +43,17 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus
+        include: *
+  health:
+    circuitbreakers:
+      enabled: true
+resilience4j.circuitbreaker:
+  configs:
+    default:
+      registerHealthIndicator: true
+      slidingWindowSize: 10
+      failureRateThreshold: 30
+      waitDurationInOpenState: 10000
+  instances:
+    backend-a:
+      base-config: default

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -52,7 +52,20 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus
+        include: *
+  health:
+    circuitbreakers:
+      enabled: true
+resilience4j.circuitbreaker:
+  configs:
+    default:
+      registerHealthIndicator: true
+      slidingWindowSize: 10
+      failureRateThreshold: 30
+      waitDurationInOpenState: 10000
+  instances:
+    backend-a:
+      base-config: default
 jwt:
   secret: ${JWT_SECRET}
 kakao-map:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -9,10 +9,9 @@ spring:
     password: ${MYSQL_PASSWORD}
   jpa:
     database: mysql
-    generate-ddl: true
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         auto_quote_keyword: true
@@ -43,6 +42,12 @@ spring:
         project-id: ${PROJECT_ID}
         bucket: ${BUCKET_NAME}
         storage-url: ${BUCKET_URL}
+  flyway:
+    url: jdbc:mariadb://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul
+    enabled: true
+    baseline-on-migrate: false
+    user: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
 management:
   endpoints:
     web:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -52,7 +52,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: *
+        include: [ "metrics", "prometheus", "circuitbreakers", "circuitbreakerevents" ]
   health:
     circuitbreakers:
       enabled: true

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,129 @@
+create table `group`
+(
+    created_at  datetime(6),
+    deleted_at  datetime(6),
+    updated_at  datetime(6),
+    id          BINARY(16) not null,
+    leader_id   binary(16),
+    group_image varchar(255),
+    name        varchar(255),
+    primary key (id)
+);
+
+create table `member`
+(
+    created_at      datetime(6),
+    deleted_at      datetime(6),
+    updated_at      datetime(6),
+    device_token_id BINARY(16),
+    id              BINARY(16) not null,
+    auth_type       enum ('APPLE','KAKAO'),
+    nickname        varchar(255) not null,
+    profile_image   varchar(255),
+    role            enum ('ROLE_ADMIN','ROLE_USER'),
+    client_id       tinytext     not null,
+    primary key (id)
+);
+create table device_token
+(
+    created_at   datetime(6),
+    deleted_at   datetime(6),
+    updated_at   datetime(6),
+    id           BINARY(16) not null,
+    device_token varchar(255),
+    primary key (id)
+);
+create table friend
+(
+    created_at       datetime(6),
+    deleted_at       datetime(6),
+    updated_at       datetime(6),
+    `from_member_id` BINARY(16),
+    id               BINARY(16) not null,
+    `to_member_id`   BINARY(16),
+    friend_status    enum ('ACCEPTED','BLOCKED','DENIED','EXPIRED','REQUESTED'),
+    primary key (id)
+);
+create table group_member
+(
+    is_share          bit,
+    is_shared_once    bit,
+    latitude          float(53),
+    longitude         float(53),
+    created_at        datetime(6),
+    deleted_at        datetime(6),
+    updated_at        datetime(6),
+    group_id          BINARY(16),
+    id                BINARY(16) not null,
+    member_id         BINARY(16),
+    group_invite_code enum ('ACCEPTED','BLOCKED','DENIED','EXPIRED','REQUESTED'),
+    primary key (id)
+);
+create table place
+(
+    latitude          float(53),
+    longitude         float(53),
+    created_at        datetime(6),
+    deleted_at        datetime(6),
+    updated_at        datetime(6),
+    id                BINARY(16) not null,
+    place_name        varchar(255) not null,
+    place_url         varchar(255),
+    road_address_name varchar(255),
+    primary key (id)
+);
+create table plan
+(
+    created_at datetime(6),
+    deleted_at datetime(6),
+    plan_day   datetime(6),
+    updated_at datetime(6),
+    group_id   BINARY(16),
+    id         BINARY(16) not null,
+    place_id   BINARY(16),
+    name       varchar(255) not null,
+    primary key (id)
+);
+create table plan_member
+(
+    is_plan_maker    bit,
+    created_at       datetime(6),
+    deleted_at       datetime(6),
+    updated_at       datetime(6),
+    id               BINARY(16) not null,
+    `member_id`      BINARY(16),
+    plan_id          BINARY(16),
+    plan_invite_code enum ('ACCEPTED','DENIED','EXPIRED','REQUESTED'),
+    primary key (id)
+);
+create table refresh_token
+(
+    id          BINARY(16) not null,
+    token_key   varchar(255),
+    token_value varchar(255),
+    primary key (id)
+);
+alter table `member`
+    add constraint unique_device_token_id unique (device_token_id);
+alter table `member`
+    add constraint unique_member_nickname unique (nickname);
+alter table plan
+    add constraint unique_plan_place_id unique (place_id);
+alter table `member`
+    add constraint fk_member_device_token_id foreign key (device_token_id) references device_token (id);
+alter table friend
+    add constraint fk_friend_from_member_id foreign key (`from_member_id`) references `member` (id);
+alter table friend
+    add constraint fk_friend_to_member_id foreign key (`to_member_id`) references `member` (id);
+alter table group_member
+    add constraint fk_group_member_group_id foreign key (group_id) references `group` (id);
+alter table group_member
+    add constraint fk_group_member_member_id foreign key (member_id) references `member` (id);
+alter table plan
+    add constraint fk_plan_group_id foreign key (group_id) references `group` (id);
+alter table plan
+    add constraint fk_plan_place_id foreign key (place_id) references place (id);
+alter table plan_member
+    add constraint fk_plan_member_member_id foreign key (`member_id`) references `member` (id);
+alter table plan_member
+    add constraint fk_plan_member_plan_id foreign key (plan_id) references plan (id);

--- a/backend/src/test/java/com/twtw/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/twtw/backend/BackendApplicationTests.java
@@ -1,12 +1,13 @@
 package com.twtw.backend;
 
-import com.twtw.backend.support.exclude.ExcludeTest;
-
+import com.twtw.backend.support.testcontainer.ContainerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
-class BackendApplicationTests extends ExcludeTest {
+@ContextConfiguration(initializers = ContainerTest.class)
+class BackendApplicationTests {
 
     @Test
     void contextLoads() {}

--- a/backend/src/test/java/com/twtw/backend/domain/friend/controller/FriendControllerTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/friend/controller/FriendControllerTest.java
@@ -1,25 +1,11 @@
 package com.twtw.backend.domain.friend.controller;
 
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
-import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.twtw.backend.domain.friend.dto.request.FriendRequest;
 import com.twtw.backend.domain.friend.dto.request.FriendUpdateRequest;
 import com.twtw.backend.domain.friend.dto.response.FriendResponse;
 import com.twtw.backend.domain.friend.entity.FriendStatus;
 import com.twtw.backend.domain.friend.service.FriendService;
 import com.twtw.backend.support.docs.RestDocsTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -29,6 +15,18 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
 import java.util.UUID;
+
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentRequest;
+import static com.twtw.backend.support.docs.ApiDocsUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("FriendController의")
 @WebMvcTest(FriendController.class)
@@ -63,6 +61,33 @@ class FriendControllerTest extends RestDocsTest {
     }
 
     @Test
+    @DisplayName("친구 전체 조회 캐시 API가 수행되는가")
+    void getFriendsWithCache() throws Exception {
+        // given
+        final List<FriendResponse> expected =
+                List.of(
+                        new FriendResponse(UUID.randomUUID(), "정해진", "http://hojiniSelfie"),
+                        new FriendResponse(UUID.randomUUID(), "주어진", "http://hojiniSelfCamera"));
+        given(friendService.getFriendsWithCache()).willReturn(expected);
+
+        // when
+        final ResultActions perform =
+                mockMvc.perform(
+                        get("/friends/all/cache")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+
+        // then
+        perform.andExpect(status().isOk()).andExpect(jsonPath("$").isArray());
+
+        // docs
+        perform.andDo(print())
+                .andDo(document("get all friends with cache", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
     @DisplayName("친구 상태별 조회 API가 수행되는가")
     void getFriendsByStatus() throws Exception {
         // given
@@ -89,6 +114,37 @@ class FriendControllerTest extends RestDocsTest {
                 .andDo(
                         document(
                                 "get friends by status",
+                                getDocumentRequest(),
+                                getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("친구 상태별 조회 캐시 API가 수행되는가")
+    void getFriendsByStatusWithCache() throws Exception {
+        // given
+        final List<FriendResponse> expected =
+                List.of(
+                        new FriendResponse(UUID.randomUUID(), "호전", "http://HJ39Selfie"),
+                        new FriendResponse(UUID.randomUUID(), "후진", "http://HJ39SelfCamera"));
+        given(friendService.getFriendsByStatusWithCache(any())).willReturn(expected);
+
+        // when
+        final ResultActions perform =
+                mockMvc.perform(
+                        get("/friends/cache?friendStatus=REQUESTED")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+
+        // then
+        perform.andExpect(status().isOk()).andExpect(jsonPath("$").isArray());
+
+        // docs
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "get friends by status with cache",
                                 getDocumentRequest(),
                                 getDocumentResponse()));
     }
@@ -153,7 +209,7 @@ class FriendControllerTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("친구 이름으로 검색 API가 수행되는가")
+    @DisplayName("친구 닉네임으로 검색 API가 수행되는가")
     void getFriendByName() throws Exception {
         // given
         final List<FriendResponse> expected =
@@ -177,5 +233,32 @@ class FriendControllerTest extends RestDocsTest {
         // docs
         perform.andDo(print())
                 .andDo(document("get search friend", getDocumentRequest(), getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("친구 닉네임으로 검색 캐시 API가 수행되는가")
+    void getFriendByNameWithCache() throws Exception {
+        // given
+        final List<FriendResponse> expected =
+                List.of(
+                        new FriendResponse(UUID.randomUUID(), "호진정", "http://hojiniSelfie"),
+                        new FriendResponse(UUID.randomUUID(), "진정해", "http://hojiniSelfCamera"));
+        given(friendService.getFriendByNicknameWithCache(any())).willReturn(expected);
+
+        // when
+        final ResultActions perform =
+                mockMvc.perform(
+                        get("/friends/search/cache?nickname=hojin")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(
+                                        "Authorization",
+                                        "Bearer wefa3fsdczf32.gaoiuergf92.gb5hsa2jgh"));
+
+        // then
+        perform.andExpect(status().isOk()).andExpect(jsonPath("$").isArray());
+
+        // docs
+        perform.andDo(print())
+                .andDo(document("get search friend with cache", getDocumentRequest(), getDocumentResponse()));
     }
 }

--- a/backend/src/test/java/com/twtw/backend/domain/friend/service/FriendServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/friend/service/FriendServiceTest.java
@@ -1,7 +1,5 @@
 package com.twtw.backend.domain.friend.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.twtw.backend.domain.friend.dto.request.FriendRequest;
 import com.twtw.backend.domain.friend.dto.request.FriendUpdateRequest;
 import com.twtw.backend.domain.friend.dto.response.FriendResponse;
@@ -12,13 +10,15 @@ import com.twtw.backend.domain.member.entity.AuthType;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.member.entity.OAuth2Info;
 import com.twtw.backend.support.service.LoginTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("FriendService의")
 class FriendServiceTest extends LoginTest {
@@ -69,6 +69,7 @@ class FriendServiceTest extends LoginTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("친구 목록 조회가 수행되는가")
     void getFriends() {
         // given
@@ -106,6 +107,7 @@ class FriendServiceTest extends LoginTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("닉네임을 통한 친구 조회가 수행되는가")
     void getFriendByNickname() {
         // given

--- a/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/group/service/GroupServiceTest.java
@@ -1,7 +1,5 @@
 package com.twtw.backend.domain.group.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.twtw.backend.domain.group.dto.request.InviteGroupRequest;
 import com.twtw.backend.domain.group.dto.request.JoinGroupRequest;
 import com.twtw.backend.domain.group.dto.request.MakeGroupRequest;
@@ -14,12 +12,14 @@ import com.twtw.backend.domain.group.repository.GroupRepository;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.service.LoginTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("GroupService의")
 class GroupServiceTest extends LoginTest {
@@ -87,6 +87,7 @@ class GroupServiceTest extends LoginTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("위치 공유를 공개 -> 비공개 변경이 가능한가")
     void changeShare() {
         // given

--- a/backend/src/test/java/com/twtw/backend/domain/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/member/repository/MemberRepositoryTest.java
@@ -1,20 +1,18 @@
 package com.twtw.backend.domain.member.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.twtw.backend.domain.member.dto.request.DeviceTokenRequest;
 import com.twtw.backend.domain.member.entity.DeviceToken;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.repository.RepositoryTest;
-
 import jakarta.persistence.EntityManager;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("MemberRepository의")
 class MemberRepositoryTest extends RepositoryTest {
@@ -46,8 +44,6 @@ class MemberRepositoryTest extends RepositoryTest {
 
         // when
         memberRepository.deleteById(memberId);
-        em.flush();
-        em.clear();
 
         // then
         assertThat(memberRepository.findById(memberId)).isEmpty();

--- a/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/member/service/AuthServiceTest.java
@@ -1,7 +1,5 @@
 package com.twtw.backend.domain.member.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.twtw.backend.domain.member.dto.request.MemberSaveRequest;
 import com.twtw.backend.domain.member.dto.request.OAuthRequest;
 import com.twtw.backend.domain.member.dto.response.AfterLoginResponse;
@@ -12,14 +10,15 @@ import com.twtw.backend.domain.member.repository.MemberRepository;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.database.DatabaseTest;
 import com.twtw.backend.support.exclude.ExcludeTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @DatabaseTest
 @DisplayName("AuthService의 ")
-public class AuthServiceTest extends ExcludeTest {
+class AuthServiceTest extends ExcludeTest {
 
     @Autowired private AuthService authService;
 

--- a/backend/src/test/java/com/twtw/backend/domain/plan/service/PlanServiceTest.java
+++ b/backend/src/test/java/com/twtw/backend/domain/plan/service/PlanServiceTest.java
@@ -1,7 +1,5 @@
 package com.twtw.backend.domain.plan.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.twtw.backend.domain.group.repository.GroupRepository;
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.place.entity.CategoryGroupCode;
@@ -19,15 +17,17 @@ import com.twtw.backend.fixture.place.PlaceDetailsFixture;
 import com.twtw.backend.fixture.place.PlaceEntityFixture;
 import com.twtw.backend.fixture.plan.PlanEntityFixture;
 import com.twtw.backend.support.service.LoginTest;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("PlanService의")
 class PlanServiceTest extends LoginTest {
@@ -73,6 +73,7 @@ class PlanServiceTest extends LoginTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("계획 참여가 수행되는가")
     void joinPlan() {
         // given
@@ -98,6 +99,7 @@ class PlanServiceTest extends LoginTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("계획 나가기가 수행되는가") // TODO: 계획에 1명 있는데 나가는 경우 생각해보기
     void outPlan() {
         // given
@@ -161,6 +163,7 @@ class PlanServiceTest extends LoginTest {
     }
 
     @Test
+    @Transactional
     @DisplayName("수정이 수행되는가")
     void updatePlan() {
         // given

--- a/backend/src/test/java/com/twtw/backend/support/database/DatabaseTest.java
+++ b/backend/src/test/java/com/twtw/backend/support/database/DatabaseTest.java
@@ -12,7 +12,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Transactional
 @ActiveProfiles("test")
 @Target(ElementType.TYPE)
 @Import(QuerydslConfig.class)

--- a/backend/src/test/java/com/twtw/backend/support/database/ResetDatabase.java
+++ b/backend/src/test/java/com/twtw/backend/support/database/ResetDatabase.java
@@ -1,0 +1,17 @@
+package com.twtw.backend.support.database;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class ResetDatabase {
+
+    @Autowired
+    private Flyway flyway;
+
+    public void reset() {
+        flyway.clean();
+        flyway.migrate();
+    }
+}

--- a/backend/src/test/java/com/twtw/backend/support/exclude/ExcludeTest.java
+++ b/backend/src/test/java/com/twtw/backend/support/exclude/ExcludeTest.java
@@ -1,37 +1,27 @@
 package com.twtw.backend.support.exclude;
 
+import com.twtw.backend.domain.notification.messagequeue.FcmProducer;
+import com.twtw.backend.support.database.ResetDatabase;
+import com.twtw.backend.support.testcontainer.ContainerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
-import com.twtw.backend.config.rabbitmq.RabbitMQConfig;
-import com.twtw.backend.domain.location.controller.LocationController;
-import com.twtw.backend.domain.notification.messagequeue.FcmProducer;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.springframework.amqp.rabbit.core.RabbitAdmin;
-import org.springframework.boot.actuate.autoconfigure.amqp.RabbitHealthContributorAutoConfiguration;
-import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
-
-@ActiveProfiles("test")
+@Import(ResetDatabase.class)
+@ContextConfiguration(initializers = ContainerTest.class)
 public abstract class ExcludeTest {
 
-    @MockBean private RabbitAutoConfiguration rabbitAutoConfiguration;
-
-    @MockBean private RabbitMQConfig rabbitMQConfig;
-
-    @MockBean private RabbitAdmin rabbitAdmin;
-
-    @MockBean
-    private RabbitHealthContributorAutoConfiguration rabbitHealthContributorAutoConfiguration;
-
-    @MockBean private LocationController locationController;
-
     @MockBean private FcmProducer fcmProducer;
+    @Autowired private ResetDatabase resetDatabase;
 
     @BeforeEach
     void setUp() {
         doNothing().when(fcmProducer).sendNotification(any());
+        resetDatabase.reset();
     }
 }

--- a/backend/src/test/java/com/twtw/backend/support/repository/EnableDataJpa.java
+++ b/backend/src/test/java/com/twtw/backend/support/repository/EnableDataJpa.java
@@ -13,7 +13,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @DataJpaTest
-@ActiveProfiles("test")
 @Target(ElementType.TYPE)
 @Import(QuerydslConfig.class)
 @Retention(RetentionPolicy.RUNTIME)

--- a/backend/src/test/java/com/twtw/backend/support/repository/RepositoryTest.java
+++ b/backend/src/test/java/com/twtw/backend/support/repository/RepositoryTest.java
@@ -1,6 +1,18 @@
 package com.twtw.backend.support.repository;
 
-import com.twtw.backend.support.exclude.ExcludeTest;
+import com.twtw.backend.support.database.ResetDatabase;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
 @EnableDataJpa
-public abstract class RepositoryTest extends ExcludeTest {}
+@Import(ResetDatabase.class)
+public abstract class RepositoryTest {
+
+    @Autowired private ResetDatabase resetDatabase;
+
+    @BeforeEach
+    public void tearDown() {
+        resetDatabase.reset();
+    }
+}

--- a/backend/src/test/java/com/twtw/backend/support/service/LoginTest.java
+++ b/backend/src/test/java/com/twtw/backend/support/service/LoginTest.java
@@ -1,30 +1,45 @@
 package com.twtw.backend.support.service;
 
-import static org.mockito.Mockito.when;
-
 import com.twtw.backend.domain.member.entity.Member;
 import com.twtw.backend.domain.member.repository.MemberRepository;
 import com.twtw.backend.domain.member.service.AuthService;
+import com.twtw.backend.domain.notification.messagequeue.FcmProducer;
 import com.twtw.backend.fixture.member.MemberEntityFixture;
 import com.twtw.backend.support.database.DatabaseTest;
-import com.twtw.backend.support.exclude.ExcludeTest;
-
+import com.twtw.backend.support.database.ResetDatabase;
+import com.twtw.backend.support.testcontainer.ContainerTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 
 @DatabaseTest
-public abstract class LoginTest extends ExcludeTest {
+@Import(ResetDatabase.class)
+@ContextConfiguration(initializers = ContainerTest.class)
+public abstract class LoginTest {
 
     @MockBean protected AuthService authService;
+    @MockBean protected FcmProducer fcmProducer;
 
     @Autowired protected MemberRepository memberRepository;
+    @Autowired private ResetDatabase resetDatabase;
     protected Member loginUser;
 
     @BeforeEach
     public void setup() {
+        resetDatabase.reset();
         final Member member = MemberEntityFixture.LOGIN_MEMBER.toEntity();
         loginUser = memberRepository.save(member);
         when(authService.getMemberByJwt()).thenReturn(loginUser);
+    }
+
+    @BeforeEach
+    void setUp() {
+        doNothing().when(fcmProducer).sendNotification(any());
     }
 }

--- a/backend/src/test/java/com/twtw/backend/support/service/LoginTest.java
+++ b/backend/src/test/java/com/twtw/backend/support/service/LoginTest.java
@@ -36,6 +36,7 @@ public abstract class LoginTest {
         final Member member = MemberEntityFixture.LOGIN_MEMBER.toEntity();
         loginUser = memberRepository.save(member);
         when(authService.getMemberByJwt()).thenReturn(loginUser);
+        when(authService.getMemberIdValue()).thenReturn("123123123.123123123.123123123");
     }
 
     @BeforeEach

--- a/backend/src/test/java/com/twtw/backend/support/testcontainer/ContainerTest.java
+++ b/backend/src/test/java/com/twtw/backend/support/testcontainer/ContainerTest.java
@@ -24,12 +24,13 @@ public class ContainerTest implements
     }
 
     @Override
-    public void initialize(ConfigurableApplicationContext applicationContext) {
+    public void initialize(final ConfigurableApplicationContext applicationContext) {
         TestPropertyValues.of(
                 "spring.data.redis.host=" + REDIS_CONTAINER.getHost(),
                 "spring.data.redis.port=" + REDIS_CONTAINER.getFirstMappedPort(),
                 "spring.rabbitmq.host=" + RABBIT_MQ_CONTAINER.getHost(),
-                "spring.rabbitmq.port=" + RABBIT_MQ_CONTAINER.getAmqpPort(),
+                "spring.rabbitmq.port=" + RABBIT_MQ_CONTAINER.getMappedPort(5672),
+                "spring.rabbitmq.stomp.port=" + RABBIT_MQ_CONTAINER.getMappedPort(61613),
                 "spring.rabbitmq.username=guest",
                 "spring.rabbitmq.password=guest"
         ).applyTo(applicationContext.getEnvironment());

--- a/backend/src/test/java/com/twtw/backend/support/testcontainer/ContainerTest.java
+++ b/backend/src/test/java/com/twtw/backend/support/testcontainer/ContainerTest.java
@@ -1,0 +1,37 @@
+package com.twtw.backend.support.testcontainer;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class ContainerTest implements
+        ApplicationContextInitializer<ConfigurableApplicationContext> {
+    private static final RedisContainer REDIS_CONTAINER =
+            new RedisContainer(DockerImageName.parse("redis:latest"))
+                    .withExposedPorts(6379);
+
+    private static final RabbitMQContainer RABBIT_MQ_CONTAINER =
+            new RabbitMQContainer(DockerImageName.parse("rabbitmq:3-management-alpine"))
+                    .withExposedPorts(15672, 5672, 61613)
+                    .withPluginsEnabled("rabbitmq_web_stomp");
+
+    static {
+        REDIS_CONTAINER.start();
+        RABBIT_MQ_CONTAINER.start();
+    }
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        TestPropertyValues.of(
+                "spring.data.redis.host=" + REDIS_CONTAINER.getHost(),
+                "spring.data.redis.port=" + REDIS_CONTAINER.getFirstMappedPort(),
+                "spring.rabbitmq.host=" + RABBIT_MQ_CONTAINER.getHost(),
+                "spring.rabbitmq.port=" + RABBIT_MQ_CONTAINER.getAmqpPort(),
+                "spring.rabbitmq.username=guest",
+                "spring.rabbitmq.password=guest"
+        ).applyTo(applicationContext.getEnvironment());
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -42,3 +42,13 @@ spring:
     user: sa
     password:
     clean-disabled: false
+resilience4j.circuitbreaker:
+  configs:
+    default:
+      registerHealthIndicator: true
+      slidingWindowSize: 10
+      failureRateThreshold: 30
+      waitDurationInOpenState: 10000
+  instances:
+    backend-a:
+      base-config: default

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -24,7 +24,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         auto_quote_keyword: true
@@ -32,26 +32,13 @@ spring:
         storage_engine: innodb
         format_sql: true
     show-sql: true
-    generate-ddl: true
   h2:
     console:
       enabled: true
-  rabbitmq:
-    listener:
-      simple:
-        auto-startup: false
-      direct:
-        auto-startup: false
-      stream:
-        auto-startup: false
-    port: 5672
-    host: localhost
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-      - org.springframework.boot.autoconfigure.websocket.servlet.WebSocketMessagingAutoConfiguration
-  data:
-    redis:
-      host: redis
-      port: 6379
+  flyway:
+    url: jdbc:h2:mem:test;DATABASE_TO_UPPER=FALSE;MODE=MySQL;
+    baseline-on-migrate: true
+    enabled: true
+    user: sa
+    password:
+    clean-disabled: false

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -32,8 +32,6 @@ alertmanager:
   user: root
   ports:
     - 9093:9093
-  environment:
-    - SLACK_API_URL=${SLACK_API_URL}
   volumes:
     - ./prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml
   networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,10 +98,11 @@ services:
     user: root
     ports:
       - 9093:9093
-    environment:
-      - SLACK_API_URL=${SLACK_API_URL}
     volumes:
       - ./prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+    depends_on:
+      - backend
+      - prometheus
     networks:
       - backend
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,6 +8,14 @@ server {
     charset utf-8;
     client_max_body_size 0;
     
+    location = /api/v1/location {
+        proxy_pass http://api;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 180s;
+    }
+    
     location /api/ {
         default_type  application/octet-stream;
         include /etc/nginx/mime.types;
@@ -16,14 +24,6 @@ server {
         proxy_set_header Host $http_host;
         proxy_redirect off;
         proxy_pass http://api;
-    }
-
-    location ~ ^/api/v[0-9]+/location$ {
-        proxy_pass http://api;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_read_timeout 180s;
     }
 
     location ~* (service-worker\.js)$ {

--- a/prometheus/alertmanager.yml
+++ b/prometheus/alertmanager.yml
@@ -7,7 +7,7 @@ route:
 receivers:
   - name: 'slack-notifications'
     slack_configs:
-    - channel: '#monitoring'
+    - channel: '#server-alert'
       send_resolved: true
       title: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ end }}"
       text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 락 전략 수립
    - [STOMP] location
        - 위치를 저장하긴 하는데 동시에 오지 않을 것
        - 또한, 매번 락 걸기엔 실시간 통신이라 서버에 부담이 큼
    - [POST] images
        - 동시로 요청 와도 큰 상관 없음
    - [POST] friends/request
        - toMember, toFriend 가 교차 저장되는 경우를 고려해야 하기에 UNIQUE 제약조건 무의미
        - 시도 1
            - @Transactional 사용 및 exists로 검사하여 존재하는 경우 롤백
            - 다음은 Service 코드 일부
            
            ```java
                @Transactional
                public void addRequest(final FriendRequest friendRequest) {
                    final Member loginMember = authService.getMemberByJwt();
                    final Member member = memberService.getMemberById(friendRequest.getMemberId());
            
                    validateFriendExists(loginMember, member);
                    friendRepository.save(friendMapper.toEntity(loginMember, member));
            
                    sendNotification(
                            member.getDeviceTokenValue(), loginMember.getNickname(), loginMember.getId());
                }
            
                private void validateFriendExists(final Member loginMember, final Member member) {
                    if (friendRepository.existsByTwoMemberId(loginMember.getId(), member.getId())) {
                        throw new InvalidFriendMemberException();
                    }
                }
            ```
            
        - 시도 2
            - DB 락 사용
                - 새로운 저장이므로 낙관적 락은 사용하기 어려움
                - 비관적 읽기 락 (공유락) 사용
                - 다음은 Repository 코드 일부
                
                ```java
                    @Override
                    public boolean existsByTwoMemberId(final UUID loginMemberId, final UUID memberId) {
                        return Optional.ofNullable(
                                jpaQueryFactory
                                        .selectFrom(friend)
                                        .setLockMode(LockModeType.PESSIMISTIC_READ)
                                        .setHint("javax.persistence.lock.timeout", 3)
                                        .where(
                                                (friend.toMember
                                                        .id
                                                        .eq(loginMemberId)
                                                        .and(friend.fromMember.id.eq(memberId))
                                                        .or(
                                                                friend.fromMember
                                                                        .id
                                                                        .eq(loginMemberId)
                                                                        .and(friend.toMember.id.eq(memberId)))))
                                        .fetchFirst())
                                .isPresent();
                    }
                ```
                
        - 시도 3
            - Redis 락 사용
                - 분산 환경이므로 Redis 사용시 분산락이 적합
                - 다음은 Service 코드의 일부이며 @DistributedLock 어노테이션의 경우 직접 aop로 분산락 적용한 커스텀 어노테이션
                
                ```java
                    @Transactional
                    public void addRequest(final FriendRequest friendRequest) {
                        final Member loginMember = authService.getMemberByJwt();
                        final Member member = memberService.getMemberById(friendRequest.getMemberId());
                
                        createFriendRequestByNicknameOrder(loginMember, member);
                
                        sendNotification(
                                member.getDeviceTokenValue(), loginMember.getNickname(), loginMember.getId());
                    }
                
                    private void createFriendRequestByNicknameOrder(final Member loginMember, final Member member) {
                        if (loginMember.hasFasterNickname(member)) {
                            createFriendRequest(loginMember, member);
                            return;
                        }
                        createFriendRequest(member, loginMember);
                    }
                
                    @DistributedLock(name = "#fromMember.getNickname().concat(#toMember.getNickname())")
                    public void createFriendRequest(final Member fromMember, final Member toMember) {
                        friendRepository.save(friendMapper.toEntity(fromMember, toMember));
                    }
                ```
- API 캐싱
    - OpenAPI에는 이미 필요한 부분에 캐싱이 적용됨
    - 우리 자체 서비스의 API 중 내가 맡은 도메인의 조회 api 중 필요한 부분 수동 조회, 캐시 조회 api로 분리함
        - 흐름
        1. 캐시 조회 api를 기본으로 호출
        2. 캐시 있는 경우 캐시 조회후 반환, 없는 경우 데이터 캐싱후 반환
        3. 유저가 원하여 수동 조회 api 호출시 기존 캐싱된 데이터 모두 캐시에서 삭제후 조회한 데이터 반환
        4. 위 사이클 반복
- test container
    - Redis와 RabbitMQ를 테스트에서 제외시키기 보다는 직접 사용해 테스트할 수 있도록 도커 기반 격리된 테스트 환경 구축
- Jacoco
    - PR 생성시 테스트 커버리지 측정 및 보고되도록 설정 (하단 확인)
- Circuit Breaker
    - OpenAPI 서버 장애 상황 resilience4j를 사용하여 대비
- Flyway
    - DB 스키마 히스토리 관리 및 마이그레이션시 사용하기 위함

## 특이사항
- 분산락을 사용하기 위해 기존 Lettuce 기반 Redis 설정을 Redisson 기반으로 전환    
- 테스트 컨테이너를 적용하였으므로 Service Layer 테스트 실행시 도커 실행한 상태인지 확인하기

## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
