### PR TITLE
[FEAT] rabbitmq deadletter 처리

### DIFF
--- a/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
@@ -24,7 +24,10 @@ public class RabbitMQConfig {
 
     @Bean
     public Queue locationQueue() {
-        return new Queue(RabbitMQConstant.LOCATION_QUEUE.getName(), true);
+        return QueueBuilder.durable(RabbitMQConstant.LOCATION_QUEUE.getName())
+                .withArgument("x-dead-letter-exchange", RabbitMQConstant.DEAD_LETTER_EXCHANGE.getName())
+                .withArgument("x-dead-letter-routing-key", RabbitMQConstant.DEAD_LETTER_ROUTING_KEY.getName())
+                .build();
     }
 
     @Bean
@@ -41,7 +44,10 @@ public class RabbitMQConfig {
 
     @Bean
     public Queue notificationQueue() {
-        return new Queue(RabbitMQConstant.NOTIFICATION_QUEUE.getName(), true);
+        return QueueBuilder.durable(RabbitMQConstant.NOTIFICATION_QUEUE.getName())
+                .withArgument("x-dead-letter-exchange", RabbitMQConstant.DEAD_LETTER_EXCHANGE.getName())
+                .withArgument("x-dead-letter-routing-key", RabbitMQConstant.DEAD_LETTER_ROUTING_KEY.getName())
+                .build();
     }
 
     @Bean

--- a/backend/src/main/java/com/twtw/backend/domain/deadletter/DeadLetterConsumer.java
+++ b/backend/src/main/java/com/twtw/backend/domain/deadletter/DeadLetterConsumer.java
@@ -1,0 +1,32 @@
+package com.twtw.backend.domain.deadletter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class DeadLetterConsumer {
+
+    private final WebClient webClient;
+    private final String slackUrl;
+
+    public DeadLetterConsumer(@Value("${slack.url}") final String slackUrl) {
+        this.webClient = WebClient.create("https://hooks.slack.com/services/");
+        this.slackUrl = slackUrl;
+    }
+
+    @RabbitListener(queues = "deadletter.queue")
+    public void handleDeadLetterMessage(final String message) {
+        log.error("Dead letter received: {}", message);
+        webClient.post()
+                .uri(slackUrl)
+                .bodyValue("{\"text\": \"Dead letter received: " + message + "\"}")
+                .retrieve()
+                .bodyToMono(String.class)
+                .doOnSuccess(s -> log.info("Slack message sent: {}", s))
+                .subscribe();
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/notification/messagequeue/FcmConsumer.java
+++ b/backend/src/main/java/com/twtw/backend/domain/notification/messagequeue/FcmConsumer.java
@@ -19,11 +19,7 @@ public class FcmConsumer {
     }
 
     @RabbitListener(queues = "notification.queue")
-    public void sendNotification(final NotificationRequest request) {
-        try {
-            firebaseMessaging.send(request.toMessage());
-        } catch (FirebaseMessagingException e) {
-            log.error(e.getMessage());
-        }
+    public void sendNotification(final NotificationRequest request) throws FirebaseMessagingException {
+        firebaseMessaging.send(request.toMessage());
     }
 }

--- a/backend/src/main/java/com/twtw/backend/global/constant/RabbitMQConstant.java
+++ b/backend/src/main/java/com/twtw/backend/global/constant/RabbitMQConstant.java
@@ -12,7 +12,10 @@ public enum RabbitMQConstant {
     LOCATION_ROUTING_KEY_PREFIX("location."),
     NOTIFICATION_QUEUE("notification.queue"),
     NOTIFICATION_EXCHANGE("notification"),
-    NOTIFICATION_ROUTING_KEY("notification");
+    NOTIFICATION_ROUTING_KEY("notification"),
+    DEAD_LETTER_QUEUE("deadletter.queue"),
+    DEAD_LETTER_EXCHANGE("deadletter"),
+    DEAD_LETTER_ROUTING_KEY("deadletter");
 
     private final String name;
 }

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -83,3 +83,5 @@ tmap:
   url: ${TMAP_URL}
 firebase:
   location: ${FIREBASE_LOCATION}
+slack:
+  url: ${SLACK_URL}


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 다음과 같은 deadletter 전략 적용
    1. 기존 서비스의 큐에 데드레터 발생시 모두 동일한 데드레터 큐로 전달
    2. 로깅 및 슬랙 알림
- 이유
    - 여러 단계의 처리는 없으므로 단계를 저장하는 것은 불필요
    - 이미 슬랙 사용중이므로 다른 알림 시스템 보다는 슬랙 사용
- 추후 개선사항
    - 데드레터 큐에서 에러 발생시 대처 방안 수립
    - 데드레터 정보가 방대해질 경우 DB에 저장 (현재는 단순한 정보이므로 모두 슬랙에 전달)

## 특이사항
- 없음

## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
