### PR TITLE
[REFACTOR] 멤버 및 시큐리티 리팩토링

### DIFF
--- a/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/security/SecurityConfig.java
@@ -18,6 +18,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private static final String[] AUTH_WHITELIST = {
+            "/auth/refresh",
+            "/auth/save",
+            "/auth/login",
+            "/member/duplicate/**",
+            "/location/**",
+            "/actuator/**"};
     private final JwtFilter jwtFilter;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
@@ -30,14 +38,7 @@ public class SecurityConfig {
                 .formLogin(f -> f.disable())
                 .authorizeHttpRequests(
                         x ->
-                                x.requestMatchers(
-                                                "/auth/refresh",
-                                                "/auth/save",
-                                                "/auth/login",
-                                                "/member/duplicate/**",
-                                                "/location/**",
-                                                "/actuator/**",
-                                                "/member/test/**")
+                                x.requestMatchers(AUTH_WHITELIST)
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())

--- a/backend/src/main/java/com/twtw/backend/config/security/jwt/KeyConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/security/jwt/KeyConfig.java
@@ -1,0 +1,19 @@
+package com.twtw.backend.config.security.jwt;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.Key;
+
+@Configuration
+public class KeyConfig {
+
+    @Bean
+    public Key key(@Value("${jwt.secret}") final String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/backend/src/main/java/com/twtw/backend/domain/member/dto/response/AfterLoginResponse.java
+++ b/backend/src/main/java/com/twtw/backend/domain/member/dto/response/AfterLoginResponse.java
@@ -10,6 +10,13 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class AfterLoginResponse {
+
+    private static final AfterLoginResponse SIGNUP = AfterLoginResponse.builder()
+            .status(AuthStatus.SIGNUP).build();
     private AuthStatus status;
     private TokenDto tokenDto;
+
+    public static AfterLoginResponse ofSignup() {
+        return SIGNUP;
+    }
 }


### PR DESCRIPTION
## 추가/수정한 기능 설명
- 리팩토링 수행, 기능의 추가/수정은 없음
    - null 사용하던 코드 Optional 사용
    - Key 주입 방식 변경
    - 하드 코딩 일부 제거

## 특이사항
- initializingBean 제거 관련 참고할 만한 레퍼런스
    - [레퍼런스1](https://velog.io/@qwerty1434/InitializingBean-vs-PostConstruct)
    - [레퍼런스2](https://icandoitprogramming.tistory.com/entry/50-%EC%9D%B8%ED%84%B0%ED%8E%98%EC%9D%B4%EC%8A%A4-InitializingBean-DisposableBean)
  
- 개인적인 견해
    - 생성자로 주입할 수 있는 객체지향적으로 제공되는 기능을 어길 만큼 특별한 객체 초기화라고 생각되지 않음
    - 기존 방식 대로면 key가 final 도 아니며 환경변수를 멤버변수로 갖고 있을 이유가 없음에도 TokenProvider의 멤버 변수임

## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
