### PR TITLE
[FEAT] thread pool and retry backoff setting

### DIFF
--- a/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/rabbitmq/RabbitMQConfig.java
@@ -16,7 +16,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
@@ -132,8 +132,8 @@ public class RabbitMQConfig {
         final SimpleRabbitListenerContainerFactory factory =
                 new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
-        factory.setConcurrentConsumers(3);
-        factory.setMaxConcurrentConsumers(10);
+        factory.setConcurrentConsumers(20);
+        factory.setMaxConcurrentConsumers(200);
         factory.setRetryTemplate(retryTemplate());
         return factory;
     }
@@ -145,8 +145,10 @@ public class RabbitMQConfig {
         final SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
         retryPolicy.setMaxAttempts(3);
 
-        final FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
-        backOffPolicy.setBackOffPeriod(3000);
+        final ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+        backOffPolicy.setInitialInterval(10_000);
+        backOffPolicy.setMultiplier(1.5);
+        backOffPolicy.setMaxInterval(60_000);
 
         retryTemplate.setRetryPolicy(retryPolicy);
         retryTemplate.setBackOffPolicy(backOffPolicy);

--- a/backend/src/main/java/com/twtw/backend/config/socket/StompConfig.java
+++ b/backend/src/main/java/com/twtw/backend/config/socket/StompConfig.java
@@ -4,8 +4,11 @@ import com.twtw.backend.global.properties.RabbitMQProperties;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -37,5 +40,35 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
                 .setSystemHeartbeatReceiveInterval(HEART_BEAT_INTERVAL);
 
         registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void configureClientInboundChannel(final ChannelRegistration registration) {
+        registration.taskExecutor(inboundTaskExecutor());
+    }
+
+    @Override
+    public void configureClientOutboundChannel(final ChannelRegistration registration) {
+        registration.taskExecutor(outboundTaskExecutor());
+    }
+
+    @Bean
+    public ThreadPoolTaskExecutor inboundTaskExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(15);
+        executor.setMaxPoolSize(150);
+        executor.setThreadNamePrefix("stomp-inbound-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean
+    public ThreadPoolTaskExecutor outboundTaskExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(20);
+        executor.setMaxPoolSize(200);
+        executor.setThreadNamePrefix("stomp-outbound-");
+        executor.initialize();
+        return executor;
     }
 }


### PR DESCRIPTION
## 추가/수정한 기능 설명
- STOMP 스레드풀 설정
- RabbitMQ 스레드풀 설정
- FCM Retry Backoff 설정

## 특이사항
- 스레드풀 aws 인스턴스 성능 테스트 기반 산정
- FCM 재시도의 경우 FCM 공식 문서 기반 최소 간격 산정 및 부하 고려한 지수 백오프 적용

## check list
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했나요?
- [x] 추가/수정사항을 설명했나요?
